### PR TITLE
travis: use lxd to build the snap package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ script:
   - sudo apt-get install --yes --no-install-recommends snapd
   - sudo snap wait system seed.loaded
   - sudo snap install --classic snapcraft
-  - sudo snapcraft
+  - sudo snapcraft --use-lxd
   - make test


### PR DESCRIPTION
Travis builds should be done with LXD or destructive mode. Set ours to
use LXD instead of invoking multipass.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>