### PR TITLE
travis: build snap using destructive mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ script:
   - sudo apt-get install --yes --no-install-recommends snapd
   - sudo snap wait system seed.loaded
   - sudo snap install --classic snapcraft
-  - sudo snapcraft
+  - sudo snapcraft --destructive-mode
   - make test

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: core20
-version: 20
+version: '20'
 summary: Runtime environment based on Ubuntu 20.04
 description: |
   The base snap based on the Ubuntu 20.04 release.


### PR DESCRIPTION
Travis builds should be done with LXD or destructive mode. Set ours to
use destructive mode instead of invoking multipass.

Signed-off-by: Claudio Matsuoka <claudio.matsuoka@canonical.com>