### PR TITLE
Adjust all symlinks, including multiarch ones.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ install:
 	# customize
 	set -ex; for f in ./hooks/[0-9]*.chroot; do \
 		/bin/cp -a $$f $(DESTDIR)/tmp && \
-		if ! dpkg-architecture -c chroot $(DESTDIR) /tmp/$$(basename $$f); then \
+		if ! chroot $(DESTDIR) /tmp/$$(basename $$f); then \
                     exit 1; \
                 fi && \
 		rm -f $(DESTDIR)/tmp/$$(basename $$f); \

--- a/hook-tests/029-fix-ld-so-symlink.test
+++ b/hook-tests/029-fix-ld-so-symlink.test
@@ -2,38 +2,27 @@
 
 set -e
 
-debarch=$(dpkg --print-architecture)
+# amd64
+abis="/lib64/ld-linux-x86-64.so.2"
+# i386
+abis="$abis /lib/ld-linux.so.2"
+# ppc64el
+abis="$abis /lib64/ld64.so.2"
+# s390x
+abis="$abis /lib/ld64.so.1"
+# armhf
+abis="$abis /lib/ld-linux-armhf.so.3"
+# arm64
+abis="$abis /lib/ld-linux-aarch64.so.1"
+# riscv64
+abis="$abis /lib/ld-linux-riscv64-ld64d.so.1"
 
-case $debarch in
-	amd64)
-		abi=/lib64/ld-linux-x86-64.so.2
-		;;
-	i386)
-		abi=/lib/ld-linux.so.2
-		;;
-	ppc64el)
-		abi=/lib64/ld64.so.2
-		;;
-	s390x)
-		abi=/lib/ld64.so.1
-		;;
-	armhf)
-		abi=/lib/ld-linux-armhf.so.3
-		;;
-	arm64)
-		abi=/lib/ld-linux-aarch64.so.1
-		;;
-	riscv64)
-		abi=/lib/ld-linux-riscv64-ld64d.so.1
-		;;
-	*)
-		echo unknown architecture
-		exit 1
-		;;
-esac
-
-if [ "$(readlink -e $abi)" != "$(readlink $abi)" ]; then
-	echo "ld linker $abi is not relative"
-	readlink $abi
-	exit 1
-fi
+for abi in $abis; do
+	if [ -e "$abi" ]; then
+		if [ "$(readlink -e "$abi")" != "$(readlink "$abi")" ]; then
+			echo "ld linker $abi is not relative"
+			readlink "$abi"
+			exit 1
+		fi
+	fi
+done

--- a/hooks/029-fix-ld-so-symlink.chroot
+++ b/hooks/029-fix-ld-so-symlink.chroot
@@ -7,34 +7,24 @@ echo "Making the /lib64/ld-linux-x86-64.so.2 and similar symlinks relative"
 # This way core mounted at /snap/core*/current/... refers to the ld
 # inside the core snap, rather tha the system one.
 
-debarch=$(dpkg --print-architecture)
+# amd64
+abis="/lib64/ld-linux-x86-64.so.2"
+# i386
+abis="$abis /lib/ld-linux.so.2"
+# ppc64el
+abis="$abis /lib64/ld64.so.2"
+# s390x
+abis="$abis /lib/ld64.so.1"
+# armhf
+abis="$abis /lib/ld-linux-armhf.so.3"
+# arm64
+abis="$abis /lib/ld-linux-aarch64.so.1"
+# riscv64
+abis="$abis /lib/ld-linux-riscv64-ld64d.so.1"
 
-case $debarch in
-	amd64)
-		abi=/lib64/ld-linux-x86-64.so.2
-		;;
-	i386)
-		abi=/lib/ld-linux.so.2
-		;;
-	ppc64el)
-		abi=/lib64/ld64.so.2
-		;;
-	s390x)
-		abi=/lib/ld64.so.1
-		;;
-	armhf)
-		abi=/lib/ld-linux-armhf.so.3
-		;;
-	arm64)
-		abi=/lib/ld-linux-aarch64.so.1
-		;;
-	riscv64)
-		abi=/lib/ld-linux-riscv64-ld64d.so.1
-		;;
-	*)
-		echo unknown architecture
-		exit 1
-		;;
-esac
+for abi in $abis; do
+	if [ -e "$abi" ]; then
+		ln -f -s .."$(readlink "$abi")" "$abi"
+	fi
+done
 
-ln -f -s ../lib/"$DEB_HOST_MULTIARCH"/ld-2.*.so $abi

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -17,7 +17,6 @@ parts:
       - shellcheck
       - wget
       - distro-info
-      - dpkg-dev
     # XXX: Dirty hacks to enable building core20 on non-bionic systems.
     # Without these overrides both the PATH and LD_LIBRARY_PATH contain paths
     # in the part's install directory which binaries can be incompatible with


### PR DESCRIPTION
Fixing native arch links is not enough, as we also must fix links off armhf/i386 on arm64/amd64.