### PR TITLE
run-snapd-from-snap: check for snapd.service existing too

### DIFF
--- a/static/usr/lib/core20/run-snapd-from-snap
+++ b/static/usr/lib/core20/run-snapd-from-snap
@@ -44,11 +44,18 @@ run_on_unseeded() {
 
 # Unseeded systems need to be seeded first, this will start snapd
 # and snapd will restart itself after the seeding.
-if [ ! -e /var/lib/snapd/state.json ]; then
+set +e
+# systemctl status returns exit code 4 for missing services, and 3 for disabled
+# services
+systemctl status snapd.service
+snapdExists=$?
+if [ ! -e /var/lib/snapd/state.json ] || [ $snapdExists = 4 ] ; then
+    set -e
     if ! run_on_unseeded; then
         echo "cannot run snapd from the seed"
         exit 1
     fi
     exit 0
 fi
+set -e
 


### PR DESCRIPTION
If state.json exists, but snapd.service doesn't, then we were likely
interrupted before the snapd-seeding from /tmp was able to bootstrap the
full snapd from the snap, so we still need to do that now.

Fixes: https://bugs.launchpad.net/snapd/+bug/1845310

Signed-off-by: Ian Johnson <ian.johnson@canonical.com>