### PR TITLE
bootstrap from locally build snapd snaps too

### DIFF
--- a/static/usr/lib/core20/run-snapd-from-snap
+++ b/static/usr/lib/core20/run-snapd-from-snap
@@ -7,7 +7,8 @@ set -eux
 
 # run_on_unseeded will mount/run snapd on an unseeded system
 run_on_unseeded() {
-    SEED_SNAPD="$(find /var/lib/snapd/seed/snaps/ -name "snapd_*.snap")"
+    # XXX: read the snapd snap to bootstrap from via /var/lib/snapd/modeenv
+    SEED_SNAPD="$(find /var/lib/snapd/seed/ -name "snapd_*.snap")"
     if [ ! -e "$SEED_SNAPD" ]; then
         echo "Cannot find a seeded snapd"
         ls /var/lib/snapd/seed/snaps


### PR DESCRIPTION
An unasserted snapd snap will be located in
```
/var/lib/snapd/seed/systems/$label/snaps
```
which the current run-snapd-from-snap bootstrap code will not
find. This commit fixes this to make this work short-term.

However we will need to write the right snapd snap into the
grubenv/modeenv so that when there are multiple recovery systems
there is no confusion.