### PR TITLE
hooks: ensure console-conf@ is started after snapd.recovery-chooser-trigger.service

### DIFF
--- a/hooks/201-console-conf-after-chooser.chroot
+++ b/hooks/201-console-conf-after-chooser.chroot
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+# Ensure that console-conf is started only once the chooser detection has completed
+echo "Fix console-conf systemd unit to run after snapd recovery chooser trigger detection"
+for f in console-conf@.service serial-console-conf@.service; do
+    p="/lib/systemd/system/$f"
+    sed -i 's/After=\(.* core.start-snapd.service\)/After=\1 snapd.recovery-chooser-trigger.service/' "$p"
+    # ensure sed worked
+    grep "^After=.* snapd.recovery-chooser-trigger.service" "$p"
+done


### PR DESCRIPTION
Combined with `Type=oneshot` of the chooser trigger service, this ensures that by
the time console-conf runs, the chooser exited and optionally left a marker
file.

NOTE: this makes the boot process longer by the amount of time it takes the chooser trigger to timeout.

Related snapd PR: https://github.com/snapcore/snapd/pull/8156