### PR TITLE
Disable emergency.target & debug-shell, unless kernel cmdline is dangerous

### DIFF
--- a/static/usr/lib/systemd/system/debug-shell.service.d/core-override.conf
+++ b/static/usr/lib/systemd/system/debug-shell.service.d/core-override.conf
@@ -1,0 +1,2 @@
+[Unit]
+AssertKernelCommandLine=dangerous

--- a/static/usr/lib/systemd/system/emergency.service.d/core-override.conf
+++ b/static/usr/lib/systemd/system/emergency.service.d/core-override.conf
@@ -1,0 +1,2 @@
+[Unit]
+AssertKernelCommandLine=dangerous

--- a/static/usr/lib/systemd/system/emergency.target.d/core-override.conf
+++ b/static/usr/lib/systemd/system/emergency.target.d/core-override.conf
@@ -1,0 +1,3 @@
+[Unit]
+OnFailure=reboot.target
+OnFailureJobMode=isolate


### PR DESCRIPTION
Disable emergency.target & debug-shell, unless kernel cmdline is dangerous

systemctl start debug-shell => simply fails
systemctl isolate emergency.target => reboots the system