### PR TITLE
Add iptables package

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -58,6 +58,7 @@ apt install --no-install-recommends -y \
     tzdata \
     openssh-server \
     iproute2 \
+    iptables \
     kmod \
     udev \
     sudo \


### PR DESCRIPTION
iptables is used by snapd's firewall-control interface. Fixes
https://github.com/snapcore/core20/issues/27.