### PR TITLE
hooks/motd: disable dynamic motd, cleanup dangling symlink

### DIFF
--- a/hooks/014-set-motd.chroot
+++ b/hooks/014-set-motd.chroot
@@ -23,3 +23,7 @@ rm /etc/update-motd.d/10-help-text
 
 # remove the motd-news service files
 rm /lib/systemd/system/motd-news.{service,timer}
+rm /etc/systemd/system/timers.target.wants/motd-news.timer
+
+# disable dynamic motd
+sed -i 's/ENABLED=1/ENABLED=0/g' /etc/default/motd-news


### PR DESCRIPTION
Dynamic motd update via pam_motd is already disabled on core 18. Do it for
core20 too.

Cleanup a dangling symlink to motd-news.timer which is already removed by the
hooks.
