### PR TITLE
run-snapd-from-snap: log first snap watch better

### DIFF
--- a/static/usr/lib/core/run-snapd-from-snap
+++ b/static/usr/lib/core/run-snapd-from-snap
@@ -27,7 +27,7 @@ run_on_unseeded() {
     # seeding is done to ensure that console-conf is only started
     # after this script has finished.
     # (redirect stdin because that is what snap checks for pty)
-    /usr/bin/snap watch --last=seed < /dev/console | tee -a /dev/console
+    systemd-run --wait -p StandardOutput=journal+console -p StandardError=journal+console /usr/bin/snap watch --last=seed
 }
 
 # Unseeded systems need to be seeded first, this will start snapd


### PR DESCRIPTION
Execute `snap watch --last=seed` as a transient systemd unit, with all stderr & stdout logged to both journal and console simultaneously. This provides interactive output, as well as storage of debug logs.