### PR TITLE
static: make all of /etc/dbus-1 writable

### DIFF
--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -25,8 +25,8 @@
 /etc/writable                           auto                    persistent  none        none
 # apparmor
 /etc/apparmor.d/cache                   auto                    persistent  none        none
-# dbus system bus
-/etc/dbus-1/system.d                    auto                    persistent  transition  none
+# dbus
+/etc/dbus-1                             auto                    persistent  transition  none
 /etc/hosts                              auto                    persistent  transition  none
 /etc/iproute2                           auto                    persistent  transition  none
 /etc/modprobe.d                         auto                    persistent  transition  none


### PR DESCRIPTION
This is intended to support https://github.com/snapcore/snapd/pull/6258.

In order to have dbus-daemon look for service activation files under /var/lib/snapd, we need to drop configuration fragments into `/etc/dbus-1/session.d` and `/etc/dbus-1/system.d`. The latter was already writable so the dbus interface can poke holes in the system bus security policy, but the former was not.

Since core20 has not been finalised yet, I've changed the existing `/etc/dbus-1/system.d` writable path to `/etc/dbus-1`, to save a bind mount.