### PR TITLE
ensure that /host exists

### DIFF
--- a/hook-tests/020-extra-files.test
+++ b/hook-tests/020-extra-files.test
@@ -2,3 +2,5 @@
 
 test -d /snap
 test -d /var/snap
+
+test -d /host

--- a/hooks/020-extra-files.chroot
+++ b/hooks/020-extra-files.chroot
@@ -35,3 +35,6 @@ mkdir -p /var/lib/cloud
 
 echo "ensure snapctl is available"
 ln -s ../lib/snapd/snapctl /usr/bin/snapctl
+
+echo "creating host mounts dir"
+mkdir -p /host


### PR DESCRIPTION
The mounts from the host system will be placed under the /host directory.