### PR TITLE
hook-tests: fix extra files test

### DIFF
--- a/hook-tests/020-extra-files.test
+++ b/hook-tests/020-extra-files.test
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-test -d /snap
-test -d /var/snap
+test -d snap
+test -d var/snap
 
-test -d /host
+test -d host


### PR DESCRIPTION
The test used absolute paths and actually tested things on the host, not inside
the test root.