### PR TITLE
001-extra-packages.chroot: add dosfstools to get mkfs.vfat

### DIFF
--- a/hook-tests/001-extra-packages.test
+++ b/hook-tests/001-extra-packages.test
@@ -33,6 +33,7 @@ debconf
 debianutils
 diffutils
 distro-info-data
+dosfstools
 dpkg
 e2fsprogs
 fdisk

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -71,6 +71,7 @@ apt install --no-install-recommends -y \
     apparmor \
     netplan.io \
     ca-certificates \
+    dosfstools \
     squashfs-tools \
     console-conf \
     rfkill \

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -15,7 +15,7 @@ parts:
       - shellcheck
       - wget
       - distro-info
-    # XXX: Dirty hacks to enable building core20 on non-bionic systems.
+    # XXX: Dirty hacks to enable building core20 on non-focal systems.
     # Without these overrides both the PATH and LD_LIBRARY_PATH contain paths
     # in the part's install directory which binaries can be incompatible with
     # the ones running on our system.  We don't need those while running stage


### PR DESCRIPTION
This is need on rpi where we have filesystems that are vfat in the gadget.

Also useful for running fsck on UC20.

Fixes https://github.com/snapcore/core20/issues/37