### PR TITLE
static: add new handle_writable_defaults() to handle-writable-paths

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,9 @@ test:
 				exit 1; \
 			fi; \
 	    	done; \
+	set -ex; for f in $$(pwd)/tests/test_*.sh; do \
+		sh -e $$f;
+	done;
 
 # Display a report of files that are (still) present in /etc
 .PHONY: etc-report

--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,8 @@ test:
 			fi; \
 	    	done; \
 	set -ex; for f in $$(pwd)/tests/test_*.sh; do \
-		sh -e $$f;
-	done;
+		sh -e $$f; \
+	done
 
 # Display a report of files that are (still) present in /etc
 .PHONY: etc-report

--- a/static/usr/lib/core/handle-writable-paths
+++ b/static/usr/lib/core/handle-writable-paths
@@ -158,7 +158,7 @@ handle_writable_defaults()
         dstpath="${rootmnt}/writable/system-data"
         for fileordir in "$srcpath"/* ; do
             # skip empty $srcpath/
-            [ ! -e "$fileordir" ] && continue
+            [ ! -e "$fileordir" ] && [ ! -L "$fileordir" ] &&  continue
 
             # copy
             cp -a "$fileordir" "$dstpath"

--- a/static/usr/lib/core/handle-writable-paths
+++ b/static/usr/lib/core/handle-writable-paths
@@ -161,7 +161,7 @@ handle_writable_defaults()
             [ ! -e "$fileordir" ] && continue
 
             # copy
-            cp -a $fileordir "$dstpath"
+            cp -a "$fileordir" "$dstpath"
         done
         touch "$srcpath/.done"
 }

--- a/static/usr/lib/core/handle-writable-paths
+++ b/static/usr/lib/core/handle-writable-paths
@@ -141,6 +141,23 @@ handle_writable_paths()
 			continue
 		fi
 	done
+
+        # now apply the defaults on top
+        handle_writable_defaults
+}
+
+# handle_writable_default will apply system defaults *once* after
+# the handle_writable_path got populated
+handle_writable_defaults()
+{
+        srcpath="${rootmnt}/writable/system-data/_writable_defaults"
+        if [ ! -d "$srcpath" ] || [ -e "${srcpath}/.done" ]; then
+                return
+        fi
+
+        dstpath="${rootmnt}/writable/system-data"
+        cp -a "$srcpath/*" "$dstpath"
+        touch "$srcpath/.done"
 }
 
 main()

--- a/static/usr/lib/core/handle-writable-paths
+++ b/static/usr/lib/core/handle-writable-paths
@@ -142,8 +142,8 @@ handle_writable_paths()
 		fi
 	done
 
-        # now apply the defaults on top
-        handle_writable_defaults
+	# now apply the defaults on top
+	handle_writable_defaults
 }
 
 # handle_writable_default will apply system defaults *once* after

--- a/static/usr/lib/core/handle-writable-paths
+++ b/static/usr/lib/core/handle-writable-paths
@@ -156,7 +156,13 @@ handle_writable_defaults()
         fi
 
         dstpath="${rootmnt}/writable/system-data"
-        cp -a "$srcpath/*" "$dstpath"
+        for fileordir in "$srcpath"/* ; do
+            # skip empty $srcpath/
+            [ ! -e "$fileordir" ] && continue
+
+            # copy
+            cp -a $fileordir "$dstpath"
+        done
         touch "$srcpath/.done"
 }
 
@@ -180,6 +186,11 @@ main()
 	# IMPORTANT: ensure we synced everything back to disk
 	sync
 }
+
+# for unit test
+if [ "$TEST_IMPORT" = "1" ]; then
+    return
+fi
 
 rootmnt="$1"
 if [ -z "$rootmnt" ]; then

--- a/tests/test_ubuntu-core-rootfs.sh
+++ b/tests/test_ubuntu-core-rootfs.sh
@@ -1,0 +1,33 @@
+#!/bin/sh -e
+
+TEST_IMPORT=1
+# shellcheck disable=SC1091
+. static/usr/lib/core/handle-writable-paths
+
+rootmnt="$(mktemp -d)"
+trap 'rm -rf "$rootmnt"' EXIT
+
+# test: no _writable_defaults does not break
+mkdir -p "$rootmnt/writeable/system-data/"
+handle_writable_defaults "$rootmnt"
+
+# test: empty _writable_defaults does not break
+mkdir -p "$rootmnt/writable/system-data/_writable_defaults"
+handle_writable_defaults "$rootmnt"
+test -e "$rootmnt/writable/system-data/_writable_defaults/.done"
+# cleanup
+rm -f "$rootmnt/writable/system-data/_writable_defaults/.done"
+
+# test: file/dir in _writable_defaults
+mkdir -p "$rootmnt/writable/system-data/_writable_defaults/some-dir"
+touch "$rootmnt/writable/system-data/_writable_defaults/some-dir/some-file"
+touch "$rootmnt/writable/system-data/_writable_defaults/other-file"
+
+handle_writable_defaults "$rootmnt"
+# ensure we have the .done file
+test -e "$rootmnt/writable/system-data/_writable_defaults/.done"
+test -d "$rootmnt/writable/system-data/some-dir"
+test -e "$rootmnt/writable/system-data/some-dir/some-file"
+test -e "$rootmnt/writable/system-data/other-file"
+# cleanup
+rm -f "$rootmnt/writable/system-data/_writable_defaults/.done"

--- a/tests/test_ubuntu-core-rootfs.sh
+++ b/tests/test_ubuntu-core-rootfs.sh
@@ -10,24 +10,37 @@ trap 'rm -rf "$rootmnt"' EXIT
 # test: no _writable_defaults does not break
 mkdir -p "$rootmnt/writeable/system-data/"
 handle_writable_defaults "$rootmnt"
+echo "Testing no _writable_defaults does not break anything"
 
 # test: empty _writable_defaults does not break
 mkdir -p "$rootmnt/writable/system-data/_writable_defaults"
 handle_writable_defaults "$rootmnt"
+echo "Testing empty _writable_defaults does not break anything"
+set -x
 test -e "$rootmnt/writable/system-data/_writable_defaults/.done"
+# 3 because: "system-data", "system-data/_writable_defaults", "s-d/_w_d/.done"
+test "$(find "$rootmnt/writable/system-data/" | wc -l)" = 3
+set +x
 # cleanup
 rm -f "$rootmnt/writable/system-data/_writable_defaults/.done"
 
-# test: file/dir in _writable_defaults
+# test: file/dir/symlinks in _writable_defaults
 mkdir -p "$rootmnt/writable/system-data/_writable_defaults/some-dir"
 touch "$rootmnt/writable/system-data/_writable_defaults/some-dir/some-file"
 touch "$rootmnt/writable/system-data/_writable_defaults/other-file"
+ln -s "other-file" "$rootmnt/writable/system-data/_writable_defaults/some-link"
+ln -s "no-file" "$rootmnt/writable/system-data/_writable_defaults/broken-link"
 
 handle_writable_defaults "$rootmnt"
 # ensure we have the .done file
+echo "Testing files/dirs/symlinks in _writable_defaults work"
+set -x
 test -e "$rootmnt/writable/system-data/_writable_defaults/.done"
 test -d "$rootmnt/writable/system-data/some-dir"
 test -e "$rootmnt/writable/system-data/some-dir/some-file"
 test -e "$rootmnt/writable/system-data/other-file"
+test -L "$rootmnt/writable/system-data/some-link"
+test -L "$rootmnt/writable/system-data/broken-link"
+set +x
 # cleanup
 rm -f "$rootmnt/writable/system-data/_writable_defaults/.done"


### PR DESCRIPTION
The new handle_writable_defaults() helper will take the defaults
from $writable/system-data/_writable_defaults/ and apply them on top of
the populated $writable/system-data.

This will allow providing image defaults in a clean way.

This is https://github.com/snapcore/core-build/pull/59 for UC20.