### PR TITLE
hooks: use explicit /sbin/init to run systemd multi-user.target

### DIFF
--- a/hook-tests/102-exec-systemd-multi-user.chroot
+++ b/hook-tests/102-exec-systemd-multi-user.chroot
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+grep -q multi-user.target sbin/init

--- a/hooks/102-exec-systemd-multi-user.chroot
+++ b/hooks/102-exec-systemd-multi-user.chroot
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -eux
+
+echo "use an explicit init script executing systemd with multi-user.target"
+rm sbin/init # is normally a symlink to systemd
+cat << EOF >> sbin/init
+#!/bin/sh
+#shellcheck disable=2093
+exec /lib/systemd/systemd --unit=multi-user.target
+EOF
+


### PR DESCRIPTION
For some reason, systemd will no longer automatically run to the multi-user.target anymore, and instead stops doing things right at the basic.target, which has broken uc20 booting.

There is probably a more elegant way to do this with symlinks and stuff, but this is clean and understandable.