### PR TITLE
Makefile: updated now that focal is released

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,8 @@
 DPKG_ARCH := $(shell dpkg --print-architecture)
 LTS=$(shell ubuntu-distro-info --lts)
 DEVEL=$(shell ubuntu-distro-info --devel 2>/dev/null)
-ifeq (,$(DEVEL))
-LTS=bionic
-DEVEL=focal
-endif
 
-ifeq ($(LTS),bionic)
+ifneq (,$(DEVEL))
 BASE := $(DEVEL)-base-$(DPKG_ARCH).tar.gz
 URL := http://cdimage.ubuntu.com/ubuntu-base/daily/current/$(BASE)
 else


### PR DESCRIPTION
The ubuntu-distro-info got updated and now "focal" is the latest
LTS. This commit upates the Makefile to fetch the right base
tarfile based on this updated distro info.