### PR TITLE
static: switch /etc/cloud from synced to persistent

### DIFF
--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -52,12 +52,7 @@
 /var/lib/dbus                           auto                    persistent  none        none
 /var/lib/dhcp                           auto                    persistent  none        none
 # cloud-init
-# FIXME: we currently write an empty /writable/system-data/etc/cloud directory
-#        when creating the image.  So setting /etc/cloud to  "persistent"
-#        instead of "synced" will result all writes getting skipped. Once
-#        the image does no longer contains this empty dir this patch can be
-#        reverted.
-/etc/cloud                              auto                    synced      none        none
+/etc/cloud                              auto                    persistent  none        none
 /var/lib/cloud                          auto                    persistent  none        none
 # for various clouds like GCE
 /etc/sysctl.d                           auto                    persistent  transition  none


### PR DESCRIPTION
This commit move /etc/cloud from a synced dir to a persistent
dir. Synced dirs have strange semantics, e.g. the user cannot
remove a file that is also present in the core20 snap in the
dir without it coming back on the next reboot. Hence we want
to avoid any synced dirs.

This requires the following prereqs:
https://github.com/snapcore/core20/pull/46
https://github.com/snapcore/snapd/pull/8612

first.