### PR TITLE
hooks: make systemd-modules-load depend on mounts at /usr/lib/{firmware,modules}

### DIFF
--- a/hook-tests/110-add-modules-mount-deps-modules-load.test
+++ b/hook-tests/110-add-modules-mount-deps-modules-load.test
@@ -1,0 +1,4 @@
+#!/bin/sh -e
+
+grep "After=usr-lib-modules.mount" lib/systemd/system/systemd-modules-load.service.d/ubuntu-core-initramfs-mounts.conf
+grep "After=usr-lib-firmware.mount" lib/systemd/system/systemd-modules-load.service.d/ubuntu-core-initramfs-mounts.conf

--- a/hooks/110-add-modules-mount-deps-modules-load.chroot
+++ b/hooks/110-add-modules-mount-deps-modules-load.chroot
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# make systemd-modules-load depend on usr-lib-modules.mount and 
+# usr-lib-firmware.mount, which will be declared in the fstab from the initramfs
+
+set -ex
+
+echo "I: Making systemd-modules-load depend on usr-lib-{firmware,modules}.mount"
+
+mkdir -p /lib/systemd/system/systemd-modules-load.service.d
+
+cat > /lib/systemd/system/systemd-modules-load.service.d/ubuntu-core-initramfs-mounts.conf << EOF
+[Unit]
+After=usr-lib-modules.mount
+Requires=usr-lib-modules.mount
+After=usr-lib-firmware.mount
+Requires=usr-lib-firmware.mount
+EOF


### PR DESCRIPTION
This is necessary because the initramfs will generate mounts in /etc/fstab for /usr/lib/{modules,firmware} from /run/mnt/kernel/{modules,firmware} respectively, and so before systemd-modules-load can load modules we need those things to be mounted.

This is opened as a draft until the required ubuntu-core-initramfs changes have landed.

Also to be clear, this is NOT for beta, so it can wait til next week.