### PR TITLE
hooks: enable check that we do not use "synced" dirs

### DIFF
--- a/hooks/991-no-synced-dirs.chroot
+++ b/hooks/991-no-synced-dirs.chroot
@@ -1,9 +1,5 @@
 #!/bin/sh -ex
 
-#FIXME: once the we no longer write an empty /writable/system-data/etc/cloud 
-#       we can re-enable this test
-exit 0
-
 if grep -v '^#' </etc/system-image/writable-paths | grep synced; then
     echo "Using 'synced' in /etc/system-image/writable-paths is not allowed in core20"
     exit 1


### PR DESCRIPTION
Using "synced" in the writable-path something we do not want to
do in UC20. The user-experience is quirky, i.e. you can never
remove a file from a synced dir if that file is also available
via the underlying core snap. It will just reappear in the next
boot.