### PR TITLE
static: provide friendly message when "man" is used

### DIFF
--- a/static/usr/bin/man
+++ b/static/usr/bin/man
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "Ubuntu Core has been minimized and does not contain man-pages."
+echo "Please use https://manpages.ubuntu.com/"


### PR DESCRIPTION
Instead of the generic minimized message use a more custom
one.

This will fix https://github.com/snapcore/core20/issues/57