### PR TITLE
Copy-in launchpad's build-archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,12 @@ install:
 	tar -x --xattrs-include=* -f ../$(BASE) -C $(DESTDIR)
 	# ensure resolving works inside the chroot
 	cat /etc/resolv.conf > $(DESTDIR)/etc/resolv.conf
+	# copy-in launchpad's build archive
+	if grep -q ftpmaster.internal /etc/apt/sources.list; then \
+		cp /etc/apt/sources.list $(DESTDIR)/etc/apt/sources.list; \
+		cp /etc/apt/trusted.gpg $(DESTDIR)/etc/apt/ || true; \
+		cp -r /etc/apt/trusted.gpg.d $(DESTDIR)/etc/apt/ || true; \
+	fi
 	# since recently we're also missing some /dev files that might be
 	# useful during build - make sure they're there
 	[ -e $(DESTDIR)/dev/null ] || mknod -m 666 $(DESTDIR)/dev/null c 1 3

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -19,12 +19,6 @@ trap 'umount /proc' EXIT
 # systemd postinst needs this
 mkdir -p /var/log/journal
 
-# enable ftpmaster.internal for faster builds
-cat >/etc/apt/sources.list.d/ftmpaster.list <<EOF
-deb http://ftpmaster.internal/ubuntu/ focal main restricted universe
-deb http://ftpmaster.internal/ubuntu/ focal-updates main restricted universe
-EOF
-
 # enable the foundations ubuntu-image PPA
 echo "deb http://ppa.launchpad.net/canonical-foundations/ubuntu-image/ubuntu focal main" > /etc/apt/sources.list.d/ubuntu-image.list
 


### PR DESCRIPTION
When building snap in launchpad, one can specify build archive
(Primary or PPA), and specify if release/security/updates/proposed
should be used for a given snap build.

Use that information during core20 snap build. This way, one can
rebuild core20 snap in personal PPAs, or rebuild it with Proposed
enabled, without any sourcecode/snapcraft.yaml modifications.