### PR TITLE
Build consoleconf from git

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ install:
 		mknod -m 666 $(DESTDIR)/dev/urandom c 1 9
 	# copy static files verbatim
 	/bin/cp -a static/* $(DESTDIR)
+	cp $(SNAPCRAFT_PART_INSTALL)/../../consoleconf-deb/install/*.deb $(DESTDIR)/tmp
 	# customize
 	set -ex; for f in ./hooks/[0-9]*.chroot; do \
 		/bin/cp -a $$f $(DESTDIR)/tmp && \

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -68,11 +68,14 @@ apt install --no-install-recommends -y \
     ca-certificates \
     dosfstools \
     squashfs-tools \
-    console-conf \
     rfkill \
     wpasupplicant \
     cloud-init \
     dmsetup \
     cryptsetup
+
+# Install self-built console-conf
+find /tmp -name '*.deb' -print0 | xargs -0 apt install -y
+rm /tmp/*.deb
 
 apt autoremove -y

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -8,7 +8,35 @@ type: base
 build-base: core20
 
 parts:
+  consoleconf-deb:
+    plugin: nil
+    source: https://github.com/CanonicalLtd/subiquity.git
+    source-type: git
+    source-branch: core/focal
+    override-pull: |
+      snapcraftctl pull
+      # install build dependencies
+      export DEBIAN_FRONTEND=noninteractive
+      export DEBCONF_NONINTERACTIVE_SEEN=true
+      sudo -E apt-get build-dep -y ./
+    override-build: |
+      # unset the LD_FLAGS and LD_LIBRARY_PATH vars that snapcraft sets for us
+      # as those will point to the $SNAPCRAFT_STAGE which on re-builds will
+      # contain things like libc and friends that confuse the debian package
+      # build system
+      # TODO: should we unset $PATH to not include $SNAPCRAFT_STAGE too?
+      unset LD_FLAGS
+      unset LD_LIBRARY_PATH
+      # run the real build (but just build the binary package, and don't
+      # bother compressing it too much)
+      dpkg-buildpackage -b -Zgzip -zfast
+      cp ../console-conf_*.deb ../subiquitycore_*.deb $SNAPCRAFT_PART_INSTALL
+    stage:
+      - -console-conf_*.deb
+      - -subiquitycore_*.deb
   bootstrap:
+    after:
+      - consoleconf-deb
     plugin: make
     source: .
     build-packages:


### PR DESCRIPTION
subiquity snap is built with snapcraft from git + archive deps.

core20 installs consoleconf from the archive, however core20 is a
snap, and it should build consoleconf from git too just like
subiquity.

Signed-off-by: Dimitri John Ledkov <xnox@ubuntu.com>

I did two builds, of the current core20 and with this change applied.

$ sudo diff -ru old/ new/ 2>/dev/null | filterdiff -X '*.pyc' | diffstat
 manifest.yaml  |  407 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++--
 snapcraft.yaml |   28 ++++++++++++
 2 files changed, 431 insertions(+), 4 deletions(-)

The net change is timestamps of .pyc files + manifest & snapcraft, otherwise the core20 snap is identical.

But now, instead of installing console-conf form the archive (which was built from the subiquity core/focal branch), during core20 snap build console-conf is built as a part from subiquity core/focal branch. This allows us to drop the round-trip to the archive, and simply push updates to core/focal whenever we need to update code in console-conf.

The sample core20 snap builds are:
- current https://launchpad.net/~xnox/+snap/xnox-core20/+build/967259
- this proposal https://launchpad.net/~xnox/+snap/xnox-core20-2/+build/966999
