### PR TITLE
static: make /etc/writable mode "transition" in writable-paths

### DIFF
--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -22,7 +22,7 @@
 /tmp                                    none                    temporary   none        defaults
 /var/tmp                                auto                    persistent  transition  none
 # etc related
-/etc/writable                           auto                    persistent  none        none
+/etc/writable                           auto                    persistent  transition  none
 # apparmor
 /etc/apparmor.d/cache                   auto                    persistent  none        none
 # dbus


### PR DESCRIPTION
This will fix https://bugs.launchpad.net/snappy/+bug/1880698
by ensuring that the original content gets copied up.