### PR TITLE
hooks: remove redundancy from timezone settings

### DIFF
--- a/hooks/030-fix-timedatectl.chroot
+++ b/hooks/030-fix-timedatectl.chroot
@@ -36,9 +36,3 @@ EOF
 
 chmod 755 /usr/bin/timedatectl
 
-echo "Ensure /etc/timezone is valid"
-echo "Etc/UTC" > /etc/timezone
-
-echo "Ensure /etc/localtime is valid"
-rm -f /etc/writable/localtime
-ln -s /usr/share/zoneinfo/UTC /etc/writable/localtime

--- a/tests/test_etc-writable-symlinks.sh
+++ b/tests/test_etc-writable-symlinks.sh
@@ -2,9 +2,13 @@
 
 set -e
 
-echo "Test that the symlinks for etc/{timezone,localtime,hostname} exist"
+echo "Test that the symlinks for etc/{timezone,localtime,hostname} exist and are correct"
 set -x
 for f in timezone localtime hostname; do
     test -e $SNAPCRAFT_PRIME/etc/$f;
 done
+
+grep "Etc/UTC" $SNAPCRAFT_PRIME/etc/timezone || (cat $SNAPCRAFT_PRIME/etc/timezone ; exit 1)
+[ $(readlink -f $SNAPCRAFT_PRIME/etc/localtime) = "/usr/share/zoneinfo/Etc/UTC" ] || (ls -al $SNAPCRAFT_PRIME/etc/localtime ; exit 1)
+
 set +x


### PR DESCRIPTION
The 030-fix-timedatectl.chroot hook was doing too much, there are
reasonable defaults already from the downloaded focal.tar.gz so
we should just use them. This will also fix the issue that the
store is blocking the upload because the localtime symlink
changed.

This reverts parts of #49 but add tests to ensure we don't regress.