### PR TITLE
tests: support test_etc-writable-symlinks.sh outside snapcraft

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,9 @@ test:
 			fi; \
 	    	done; \
 	set -ex; for f in $$(pwd)/tests/test_*.sh; do \
-		sh -e $$f; \
+		if !(cd $(TESTDIR) && sh -ex $$f); then \
+			exit 1; \
+		fi; \
 	done
 
 # Display a report of files that are (still) present in /etc

--- a/tests/test_etc-writable-symlinks.sh
+++ b/tests/test_etc-writable-symlinks.sh
@@ -5,10 +5,10 @@ set -e
 echo "Test that the symlinks for etc/{timezone,localtime,hostname} exist and are correct"
 set -x
 for f in timezone localtime hostname; do
-    test -e $SNAPCRAFT_PRIME/etc/$f;
+    test -e etc/$f;
 done
 
-grep "Etc/UTC" $SNAPCRAFT_PRIME/etc/timezone || (cat $SNAPCRAFT_PRIME/etc/timezone ; exit 1)
-[ $(readlink -f $SNAPCRAFT_PRIME/etc/localtime) = "/usr/share/zoneinfo/Etc/UTC" ] || (ls -al $SNAPCRAFT_PRIME/etc/localtime ; exit 1)
+grep "Etc/UTC" etc/timezone || (cat etc/timezone ; exit 1)
+[ $(readlink -f etc/localtime) = "/usr/share/zoneinfo/Etc/UTC" ] || (ls -al etc/localtime ; exit 1)
 
 set +x

--- a/tests/test_etc-writable-symlinks.sh
+++ b/tests/test_etc-writable-symlinks.sh
@@ -9,6 +9,7 @@ for f in timezone localtime hostname; do
 done
 
 grep "Etc/UTC" etc/timezone || (cat etc/timezone ; exit 1)
-[ $(readlink -f etc/localtime) = "/usr/share/zoneinfo/Etc/UTC" ] || (ls -al etc/localtime ; exit 1)
+[ $(readlink -f etc/localtime) = "writable/localtime" ] || (ls -al etc/localtime ; exit 1)
+[ $(readlink -f etc/writable/localtime) = "/usr/share/zoneinfo/Etc/UTC" ] || (ls -al etc/writable/localtime ; exit 1)
 
 set +x


### PR DESCRIPTION
The test was relying on being run inside snapcraft. This is not
always the case so rework it to ensure it work inside snapcraft
and when run without snapcraft.