### PR TITLE
.travis.yml: use snapcraft w/ lxd to build the snap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,29 @@ language: minimal
 os: linux
 dist: bionic
 sudo: enabled
+addons:
+  snaps:
+    - name: snapcraft
+      confinement: classic
+      # candidate is needed for https://github.com/snapcore/snapcraft/pull/3218,
+      # which will go into 4.1.2, remove when 4.1.2 hits stable
+      channel: candidate
+    - name: lxd
+env:
+  global:
+    - LC_ALL=C.UTF-8
+    - LANG=C.UTF-8
+      # build with lxd because travis doesn't support focal yet, so we can't build
+      # natively
+    - SNAPCRAFT_BUILD_ENVIRONMENT=lxd
+
+install:
+  - sudo apt-get remove lxd-client lxc -y
+  - sudo apt-get autoremove
+  - sudo /snap/bin/lxd init --auto
+  - sudo usermod --append --groups lxd $USER
+
 script:
-  - sudo apt-get update
-  - sudo apt-get install --yes --no-install-recommends snapd
-  - sudo snap wait system seed.loaded
-  - sudo snap install --classic snapcraft
-  - sudo snapcraft --destructive-mode
+  - sg lxd 'snapcraft'
+  - sudo unsquashfs -d prime core20*.snap
   - make test


### PR DESCRIPTION
We can't use sudo snapcraft with snapcraft 4.0, and we should ideally be building with lxd, as that provides us with the right build-base for building the snap, regardless of what series travis currently supports.

Also we need snapcraft 4.1.2 to take advantage of snapcraft intercepting the mknod calls, otherwise the lxd container fails when trying to run the chroot things.

Fixes https://github.com/snapcore/core20/issues/66