### PR TITLE
hooks/001-extra-packages.chroot: add gdbserver

### DIFF
--- a/hook-tests/001-extra-packages.test
+++ b/hook-tests/001-extra-packages.test
@@ -122,6 +122,7 @@ tar
 tzdata
 ubuntu-keyring
 util-linux
+gdbserver
 zlib1g:amd64
 EOF
         ))

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -72,7 +72,8 @@ apt install --no-install-recommends -y \
     wpasupplicant \
     cloud-init \
     dmsetup \
-    cryptsetup
+    cryptsetup \
+    gdbserver
 
 # Install self-built console-conf
 find /tmp -name '*.deb' -print0 | xargs -0 apt install -y


### PR DESCRIPTION
gdbserver is needed in order to use the new `snap run --experimental-gdbserver` feature. Specifically, using gdbserver is much smaller than adding the full gdb package to the base snap, and allows remote gdb debugging on Ubuntu Core.

See also https://forum.snapcraft.io/t/new-experimental-snap-run-experimental-gdbserver-option/18227

Note that I tested adding both this package and the `gdb` package to the core20 snap and found these sizes:

```
$ ls -la *.snap
-rw-rw-r-- 1 user user 64000000 Jul 20 20:27 core20_upstream.snap
-rw-r--r-- 1 user user 64233472 Jul 20 20:34 core20_gdbserver.snap
-rw-r--r-- 1 user user 69267456 Jul 21 08:51 core20_gdb.snap
```

core18 PR: https://github.com/snapcore/core18/pull/163