### PR TITLE
hooks/900-cleanup-etc-var.chroot: rm cloud-init config file which we don't want

### DIFF
--- a/hooks/900-cleanup-etc-var.chroot
+++ b/hooks/900-cleanup-etc-var.chroot
@@ -22,6 +22,12 @@ rm /etc/pam.conf
 # cloud-init adds stuff here
 rm -rf /etc/profile.d
 
+# remove cloud-init file which allows all datasources, eventually we should add
+# a cloud-init configuration which specifies all allowed/known to work/good 
+# datasources, but since snapd will do this automatically after seeding, it's 
+# not critical
+rm /etc/cloud/cloud.cfg.d/90_dpkg.cfg
+
 rm /etc/rmt
 rm /etc/sysctl.conf
 rm -rf /etc/terminfo


### PR DESCRIPTION
This configuration file has the following contents:

```
# to update this file, run dpkg-reconfigure cloud-init
datasource_list: [ NoCloud, ConfigDrive, OpenNebula, DigitalOcean, Azure, AltCloud, OVF, MAAS, GCE, OpenStack, CloudSigma, SmartOS, Bigstep, Scaleway, AliYun, Ec2, CloudStack, Hetzner, IBMCloud, Oracle, Exoscale, RbxCloud, None ]
```

On Ubuntu Core, one cannot run dpkg-reconfigure for one, so the file can never
be modified in practice, and additionally we do not want to allow all possible
datasources under the sun without understanding their use cases in Ubuntu Core.

Note that already on Ubuntu Core, snapd as of 2.45.2 will write a configuration
file zzzz_snapd.cfg taking priority over this file to restrict the set of
datasources to a safe one, so we do not strictly need to delete this file, but
it will be simpler if we don't have this file.

core18 backport: https://github.com/snapcore/core18/pull/166
core backport: https://github.com/snapcore/core/pull/115