### PR TITLE
Add secureboot-db package, try #2.

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -80,3 +80,9 @@ find /tmp -name '*.deb' -print0 | xargs -0 apt install -y
 rm /tmp/*.deb
 
 apt autoremove -y
+
+case "$(dpkg --print-architecture)" in
+    amd64|i386)
+        apt install --no-install-recommends -y secureboot-db
+        ;;
+esac

--- a/static/usr/lib/systemd/system/core.start-snapd.service
+++ b/static/usr/lib/systemd/system/core.start-snapd.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Start the snapd services from the snapd snap
 RequiresMountsFor=/run
+Wants=secureboot-db.service
+After=secureboot-db.service
 
 [Service]
 ExecStart=/usr/lib/core/run-snapd-from-snap start

--- a/static/usr/lib/systemd/system/secureboot-db.service.d/core-override.conf
+++ b/static/usr/lib/systemd/system/secureboot-db.service.d/core-override.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionKernelCommandLine=snapd_recovery_mode=install


### PR DESCRIPTION
Only execute it in install mode, and ensure this is done before snapd
is started.

The goal is to have dbxupdates applied before install is performed,
such that we seal against the latest dbx state possible.