### PR TITLE
[RFC] hooks: mv docker user/group definition to extrausers

### DIFF
--- a/hooks/000-provide-uids-gids.chroot
+++ b/hooks/000-provide-uids-gids.chroot
@@ -115,7 +115,6 @@ systemd-network:x:104:109:systemd Network Management,,,:/run/systemd/netif:/bin/
 systemd-resolve:x:105:110:systemd Resolver,,,:/run/systemd/resolve:/bin/false
 systemd-bus-proxy:x:106:111:Reserved:/run/systemd:/bin/false
 _apt:x:117:65534:Reserved:/nonexistent:/bin/false
-docker:x:107:113:Reserved:/nonexistent:/bin/false
 syslog:x:108:114:Reserved:/home/syslog:/bin/false
 dnsmasq:x:109:65534:Reserved:/var/lib/misc:/bin/false
 tss:x:110:116:Reserved:/var/lib/tpm:/bin/false
@@ -150,7 +149,6 @@ systemd-network:*:16413:0:99999:7:::
 systemd-resolve:*:16413:0:99999:7:::
 systemd-bus-proxy:*:16413:0:99999:7:::
 _apt:*:16780:0:99999:7:::
-docker:*:16413:0:99999:7:::
 syslog:*:16521:0:99999:7:::
 dnsmasq:*:16644:0:99999:7:::
 tss:*:16701:0:99999:7:::
@@ -209,7 +207,6 @@ systemd-network:x:109:
 systemd-resolve:x:110:
 systemd-bus-proxy:x:111:
 kvm:x:112:
-docker:x:113:
 syslog:x:114:
 pkcs11:x:115:
 tss:x:116:
@@ -270,7 +267,6 @@ systemd-network:!::
 systemd-resolve:!::
 systemd-bus-proxy:!::
 kvm:!::
-docker:!::
 syslog:!::
 pkcs11:!::
 tss:!::
@@ -278,3 +274,33 @@ input:!::
 render:!::
 EOF
 cp /etc/gshadow /etc/gshadow.orig # We make a copy for a later sanity-compare
+
+mkdir -p /var/lib/extrausers
+
+echo "Providing the final extrausers/passwd file"
+cat > /var/lib/extrausers/passwd <<EOF
+docker:x:107:113:Reserved:/nonexistent:/bin/false
+EOF
+cp /var/lib/extrausers/passwd /var/lib/extrausers/passwd.orig # We make a copy for a later sanity-compare
+
+
+echo "Providing the final extrausers/group file"
+cat > /var/lib/extrausers/group <<EOF
+docker:x:113:
+EOF
+cp /var/lib/extrausers/group /var/lib/extrausers/group.orig # We make a copy for a later sanity-compare
+
+
+echo "Providing the final extrausers/shadow file"
+cat > /var/lib/extrausers/shadow <<EOF
+docker:*:16413:0:99999:7:::
+EOF
+cp /var/lib/extrausers/shadow /var/lib/extrausers/shadow.orig # We make a copy for a later sanity-compare
+
+
+echo "Providing the final extrausers/gshadow file"
+cat > /var/lib/extrausers/gshadow <<EOF
+docker:!::
+EOF
+cp /var/lib/extrausers/gshadow /var/lib/extrausers/gshadow.orig # We make a copy for a later sanity-compare
+

--- a/hooks/990-ensure-uids-gids.chroot
+++ b/hooks/990-ensure-uids-gids.chroot
@@ -20,6 +20,22 @@ echo "Ensure gshadow file does not change"
 diff -u /etc/gshadow /etc/gshadow.orig
 rc=$?; [ "$rc" != "0" ] && MISMATCH=1
 
+echo "Ensure extrausers passwd file does not change"
+diff -u /var/lib/extrausers/passwd /var/lib/extrausers/passwd.orig
+rc=$?; [ "$rc" != "0" ] && MISMATCH=1
+
+echo "Ensure extrausers shadow file does not change"
+diff -u /var/lib/extrausers/shadow /var/lib/extrausers/shadow.orig
+rc=$?; [ "$rc" != "0" ] && MISMATCH=1
+
+echo "Ensure extrausers group file does not change"
+diff -u /var/lib/extrausers/group /var/lib/extrausers/group.orig
+rc=$?; [ "$rc" != "0" ] && MISMATCH=1
+
+echo "Ensure extrausers gshadow file does not change"
+diff -u /var/lib/extrausers/gshadow /var/lib/extrausers/gshadow.orig
+rc=$?; [ "$rc" != "0" ] && MISMATCH=1
+
 if [ -n "$MISMATCH" ]; then
     echo "There were changes to the password database."
     echo "This usually means something wrong happened during the execution of hooks."
@@ -32,3 +48,7 @@ rm /etc/passwd.orig
 rm /etc/shadow.orig
 rm /etc/group.orig
 rm /etc/gshadow.orig
+rm /var/lib/extrausers/passwd.orig
+rm /var/lib/extrausers/shadow.orig
+rm /var/lib/extrausers/group.orig
+rm /var/lib/extrausers/gshadow.orig


### PR DESCRIPTION
This will allow users to add themselves to the docker group. This in combination
with an upgraded getent which reads from extrausers will allow the docker snap
to be used with non-root users.

Fixes: https://github.com/snapcore/core20/issues/72