### PR TITLE
static/writable-paths: make /etc/default/crda writable

### DIFF
--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -35,6 +35,8 @@
 /etc/network/if-up.d                    auto                    persistent  transition  none
 /etc/ssh                                auto                    persistent  transition  none
 /etc/sudoers.d                          auto                    persistent  transition  none
+# for wireless regulatory things
+/etc/default/crda                       auto                    persistent  transition  none
 # systemd
 /etc/systemd                            auto                    persistent  transition  none
 /var/lib/systemd                        auto                    persistent  transition  none


### PR DESCRIPTION
This file is used to manage wireless regulatory domains, so it should be
writable to allow setting REGDOMAIN in this file.

Forward-port to UC20 of https://github.com/snapcore/core/pull/117