### PR TITLE
static/writable-paths: use transition instead of none for /etc/cloud

### DIFF
--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -52,7 +52,7 @@
 /var/lib/dbus                           auto                    persistent  none        none
 /var/lib/dhcp                           auto                    persistent  none        none
 # cloud-init
-/etc/cloud                              auto                    persistent  none        none
+/etc/cloud                              auto                    persistent  transition  none
 /var/lib/cloud                          auto                    persistent  none        none
 # for various clouds like GCE
 /etc/sysctl.d                           auto                    persistent  transition  none


### PR DESCRIPTION
We still need files from the core20 snap to show up in writable for /etc/cloud,
otherwise cloud-init does not work correctly out-of-the-box. As such, use
transition instead of none, which will copy files from the core20 snap to
/etc/cloud on writable.

This fixes a bug introduced as part of #54 and will fix cloud-init with uc20 again.