### PR TITLE
hooks: adapt to motd-news-config not being included in image any more

### DIFF
--- a/hook-tests/014-set-motd.test
+++ b/hook-tests/014-set-motd.test
@@ -4,6 +4,7 @@ set -e
 
 grep -q "This Ubuntu Core 20 machine is a tiny" etc/motd
 
+test ! -e etc/default/motd-news
 test ! -e etc/update-motd.d/10-help-text
 test ! -e lib/systemd/system/motd-news.service
 test ! -e lib/systemd/system/motd-news.timer

--- a/hooks/014-set-motd.chroot
+++ b/hooks/014-set-motd.chroot
@@ -28,6 +28,3 @@ rm /etc/update-motd.d/60-unminimize
 # remove the motd-news service files
 rm /lib/systemd/system/motd-news.{service,timer}
 rm /etc/systemd/system/timers.target.wants/motd-news.timer
-
-# disable dynamic motd
-sed -i 's/ENABLED=1/ENABLED=0/g' /etc/default/motd-news


### PR DESCRIPTION
As outlined in [bug #1888575][0], the configuration file for motd-news was split out into a separate `motd-news-config` package.  It looks like that package is no longer being included in the core20 image, which breaks the build:

```
2020-09-04T01:55:34.2385780Z + sed -i s/ENABLED=1/ENABLED=0/g /etc/default/motd-news
2020-09-04T01:55:34.2398295Z sed: can't read /etc/default/motd-news: No such file or directory
2020-09-04T01:55:34.2402226Z + exit 1
2020-09-04T01:55:34.2405398Z make: *** [Makefile:35: install] Error 1
```

As the hooks were trying to disable the feature, I've just adjusted the hooks to not try and patch motd-news's config file, and verify that it isn't present with a test.

[0]: https://bugs.launchpad.net/ubuntu/+source/base-files/+bug/1888575