### PR TITLE
.travis.yml: use stable snapcraft now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,6 @@ addons:
   snaps:
     - name: snapcraft
       confinement: classic
-      # candidate is needed for https://github.com/snapcore/snapcraft/pull/3218,
-      # which will go into 4.1.2, remove when 4.1.2 hits stable
-      channel: candidate
     - name: lxd
 env:
   global:


### PR DESCRIPTION
The associated fix has now been released and we can go back to using snapcraft
from stable again.