### PR TITLE
Make the version number date-based.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,6 @@
 name: core20
-version: "20"
+# version: "20"
+adopt-info: bootstrap
 summary: Runtime environment based on Ubuntu 20.04
 description: |
   The base snap based on the Ubuntu 20.04 release.
@@ -57,6 +58,10 @@ parts:
     # in the part's install directory which binaries can be incompatible with
     # the ones running on our system.  We don't need those while running stage
     # and prime anyway.
+    override-pull: |
+      unset LD_LIBRARY_PATH;
+      snapcraftctl set-version "$(/bin/date +%Y%m%d)"
+      snapcraftctl pull
     override-stage: |
       unset LD_LIBRARY_PATH;
       export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/snap/bin"


### PR DESCRIPTION
As in the description. We have the same scheme (implementation as well) in core18 right now.