### PR TITLE
Resurrect bash-completion

### DIFF
--- a/hooks/900-cleanup-etc-var.chroot
+++ b/hooks/900-cleanup-etc-var.chroot
@@ -20,7 +20,7 @@ rm /etc/debian_version
 rm /etc/pam.conf
 
 # cloud-init adds stuff here
-rm -rf /etc/profile.d
+rm -rvf /etc/profile.d/Z99-cloud*
 
 # remove cloud-init file which allows all datasources, eventually we should add
 # a cloud-init configuration which specifies all allowed/known to work/good 


### PR DESCRIPTION
Previously everything was deleted from profile.d

Now only cloud-init things are deleted.

This leaves base-files' profile.d hook to ensure locales are set and bash-completion hook that enables bash-completion.

We have had previously requests to re-enable bash-completion. We install it, and don't activate it by default.