### PR TITLE
hooks: update xdg-settings to support subcommands

### DIFF
--- a/hooks/500-create-xdg.chroot
+++ b/hooks/500-create-xdg.chroot
@@ -31,24 +31,40 @@ EOF
 
 cat >/usr/bin/xdg-settings <<'EOF'
 #!/bin/bash
-#
 set -e
 set -o pipefail
-
-# we need to add a "cut -b4-" everyhwere because
-# `dbus-send --print-reply=literal` indents the output by 3 spaces
-# (hardcoded in dbus-print-message.c:print_iter)
-
-if [ "$1" = "get" ]; then
-   dbus-send --print-reply=literal --session --dest=io.snapcraft.Settings /io/snapcraft/Settings io.snapcraft.Settings.Get string:"$2" | cut -b4-
-elif [ "$1" = "check" ]; then
-   dbus-send --print-reply=literal --session --dest=io.snapcraft.Settings /io/snapcraft/Settings io.snapcraft.Settings.Check string:"$2" string:"$3" | cut -b4-
-elif [ "$1" = "set" ]; then
-   # timeout of 300s to ensure the user has enough time to make a decision
-   dbus-send --reply-timeout=300000 --print-reply=literal --session --dest=io.snapcraft.Settings /io/snapcraft/Settings io.snapcraft.Settings.Set string:"$2" string:"$3" | cut -b4-
-else
-   echo "unknown action $2"
-fi
+# We need to add a "cut -b4-" everywhere because `dbus-send
+# --print-reply=literal` indents the output by 3 spaces (hard-coded in
+# dbus-print-message.c:print_iter).
+# TODO: change this to busctl, it's much easier to use.
+case "$1" in
+    get)
+        if [ $# -eq 3 ]; then
+            dbus-send --print-reply=literal --session --dest=io.snapcraft.Settings /io/snapcraft/Settings io.snapcraft.Settings.GetSub string:"$2" string:"$3" | cut -b4-
+        else
+            dbus-send --print-reply=literal --session --dest=io.snapcraft.Settings /io/snapcraft/Settings io.snapcraft.Settings.Get string:"$2" | cut -b4-
+        fi
+        ;;
+    set)
+        # Timeout of 300s to ensure the user has enough time to make a decision
+        if [ $# -eq 4 ]; then
+            dbus-send --reply-timeout=300000 --print-reply=literal --session --dest=io.snapcraft.Settings /io/snapcraft/Settings io.snapcraft.Settings.SetSub string:"$2" string:"$3" string:"$4" | cut -b4-
+        else
+            dbus-send --reply-timeout=300000 --print-reply=literal --session --dest=io.snapcraft.Settings /io/snapcraft/Settings io.snapcraft.Settings.Set string:"$2" string:"$3" | cut -b4-
+        fi
+        ;;
+    check)
+        if [ $# -eq 4 ]; then
+            dbus-send --print-reply=literal --session --dest=io.snapcraft.Settings /io/snapcraft/Settings io.snapcraft.Settings.CheckSub string:"$2" string:"$3" string:"$4" | cut -b4-
+        else
+            dbus-send --print-reply=literal --session --dest=io.snapcraft.Settings /io/snapcraft/Settings io.snapcraft.Settings.Check string:"$2" string:"$3" | cut -b4-
+        fi
+        ;;
+    *)
+        >&2 echo "unknown action $*"
+        exit 1
+        ;;
+esac
 EOF
 chmod 755 /usr/bin/xdg-settings
 


### PR DESCRIPTION
Update to the current version of https://github.com/snapcore/snapd/blob/master/tests/lib/snaps/test-snapd-xdg-settings/bin/xdg-settings-wrapper which supports subcommands

Currently settings the default mailto handler from thunderbird fails because the installed wrapper doesn't handle subcommands, which was added in snapd with https://github.com/snapcore/snapd/pull/7129 but the core wrapper never got updated

Testcase
$ snap install thunderbird
$ xdg-settings set default-url-scheme-handler mailto thunderbird_thunderbird.desktop
$ snap run --shell thunderbird
$ xdg-settings get default-url-scheme-handler mailto
$ xdg-settings get default-url-scheme-handler mailto
NOT-THIS-SNAP.desktop
$ dbus-send --session --dest=io.snapcraft.Settings --type=method_call --print-reply /io/snapcraft/Settings io.snapcraft.Settings.GetSub string:'default-url-scheme-handler' string:'mailto'
method return time=1607963212.876053 sender=:1.387 -> destination=:1.388 serial=6 reply_serial=2
   string "thunderbird.desktop"

Checking /usr/bin/xdg-settings it's outdated, in the thunderbird environment with the current snapd tests wrapper

$ bash xdg-settings-wrapper get default-url-scheme-handler mailto
thunderbird.desktop

The update there is copying the current content from tests/lib/snaps/test-snapd-xdg-settings/bin/xdg-settings-wrapper so should be working
