### PR TITLE
ci: add a Github Actions port of the Travis workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,3 +20,7 @@ jobs:
         run: |
           sudo unsquashfs -d prime ${{ steps.snapcraft.outputs.snap }}
           make test
+      - uses: actions/upload-artifact@v2
+        with:
+          name: snaps
+          path: ${{ steps.snapcraft.outputs.snap }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,22 @@
+name: Test
+on:
+  pull_request:
+  push:
+    branches: [ 'master*' ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install testing deps
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          sudo apt-get update -q
+          sudo apt-get install -qy make squashfs-tools
+      - uses: snapcore/action-build@v1
+        id: snapcraft
+      - name: Test
+        run: |
+          sudo unsquashfs -d prime ${{ steps.snapcraft.outputs.snap }}
+          make test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,17 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install testing deps
-        run: |
-          export DEBIAN_FRONTEND=noninteractive
-          sudo apt-get update -q
-          sudo apt-get install -qy make squashfs-tools
       - uses: snapcore/action-build@v1
         id: snapcraft
-      - name: Test
-        run: |
-          sudo unsquashfs -d prime ${{ steps.snapcraft.outputs.snap }}
-          make test
       - uses: actions/upload-artifact@v2
         with:
           name: snaps


### PR DESCRIPTION
This PR contains a port of the Travis CI workflow over to Github Actions.  As the travis-ci.org website has a big banner saying that it will soon be shut down, it seems prudent to move to an alternative.

I've made use of the `snapcore/action-build@v1` action in the workflow, which takes care of installing Snapcraft and running the build via LXD (so it is isolated from the Ubuntu install on the Github runner).  The workflow is set to run on pull requests and pushes to branches matching `master*`.  It won't run for this pull requests until the target branch contains the workflow though.

A sample run from my own repository can be seen here:

https://github.com/jhenstridge/core20/actions/runs/766038505

If this looks interesting, it should be pretty easy to copy for core, core18 and core22.