### PR TITLE
hooks: add mDNS hostname resolution support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ install:
 	# copy static files verbatim
 	/bin/cp -a static/* $(DESTDIR)
 	/bin/cp $(SNAPCRAFT_PART_INSTALL)/../../consoleconf-deb/install/*.deb $(DESTDIR)/tmp
+	/bin/cp $(SNAPCRAFT_PART_INSTALL)/../../avahi-daemon-equiv-deb/install/*.deb $(DESTDIR)/tmp
 	# customize
 	set -ex; for f in ./hooks/[0-9]*.chroot; do \
 		/bin/cp -a $$f $(DESTDIR)/tmp && \

--- a/hook-tests/013-add-mdns-hostname-resolution.test
+++ b/hook-tests/013-add-mdns-hostname-resolution.test
@@ -1,0 +1,26 @@
+#!/bin/sh -e
+
+# mdns support is enabled in nsswitch.conf
+grep -q "^hosts:.*mdns4_minimal" etc/nsswitch.conf
+
+# Avahi is not present in the base
+if [ -e usr/sbin/avahi-daemon ]; then
+    echo "The real avahi-daemon ended up in the image"
+    exit 1
+fi
+
+expected_plugins="$(find lib/ -name libnss_mdns4_minimal.so.2)"
+unexpected_plugins="$(find lib/ -name libnss_mdns.so.2 -o -name libnss_mdns_minimal.so.2 -o -name libnss_mdns4.so.2 -o -name libnss_mdns6.so.2 -o -name libnss_mdns6_minimal.so.2)"
+
+# There must be at least one copy of libnss_mdns4_minimal.so.2
+if [ -z "$expected_plugins" ]; then
+    echo "There must be a copy of libnss_mdns4_minimal.so.2 on the image"
+    exit 1
+fi
+
+# None of the other libnss-mdns plugins should be installed
+if [ -n "$unexpected_plugins" ]; then
+    echo "Found unexpected NSS plugins in image:"
+    echo "$unexpected_plugins"
+    exit 1
+fi

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -77,7 +77,7 @@ apt install --no-install-recommends -y \
     cryptsetup \
     gdbserver
 
-# Install self-built console-conf
+# Install self-built console-conf and fake avahi-daemon
 find /tmp -name '*.deb' -print0 | xargs -0 apt install -y
 rm /tmp/*.deb
 

--- a/hooks/012-add-foreign-libc6.chroot
+++ b/hooks/012-add-foreign-libc6.chroot
@@ -10,12 +10,6 @@ if [ "$(dpkg --print-architecture)" = "amd64" ]; then
 
     echo "I: Installing libc6:i386 in amd64 image"
     apt-get -y install libc6:i386
-
-    echo "I: Removing /var/lib/apt/lists/*"
-    find /var/lib/apt/lists/ -type f -print0 | xargs -0 rm -f
-
-    echo "I: Removing /var/cache/apt/*.bin"
-    rm -f /var/cache/apt/*.bin
 fi
 
 echo "I: Checking if we are arm64 and libc6:armhf should be installed"
@@ -28,11 +22,5 @@ if [ "$(dpkg --print-architecture)" = "arm64" ]; then
 
     echo "I: Installing libc6:armhf in arm64 image"
     apt-get -y install libc6:armhf
-
-    echo "I: Removing /var/lib/apt/lists/*"
-    find /var/lib/apt/lists/ -type f -print0 | xargs -0 rm -f
-
-    echo "I: Removing /var/cache/apt/*.bin"
-    rm -f /var/cache/apt/*.bin
 fi
 

--- a/hooks/013-add-mdns-hostname-resolution.chroot
+++ b/hooks/013-add-mdns-hostname-resolution.chroot
@@ -1,0 +1,26 @@
+#!/bin/sh -ex
+
+export DEBIAN_FRONTEND=noninteractive
+
+echo "Installing libnss-mdns"
+apt-get install -y libnss-mdns
+
+# Install additional multi-arch versions of modules
+case "$(dpkg --print-architecture)" in
+    amd64)
+        apt-get install -y libnss-mdns:i386
+        ;;
+    arm64)
+        apt-get install -y libnss-mdns:armhf
+        ;;
+    *)
+        ;;
+esac
+
+echo "Removing extra mdns NSS modules"
+# Everything but libnss_mdns4_minimal
+rm -f /lib/*/libnss_mdns.so.2
+rm -f /lib/*/libnss_mdns_minimal.so.2
+rm -f /lib/*/libnss_mdns4.so.2
+rm -f /lib/*/libnss_mdns6.so.2
+rm -f /lib/*/libnss_mdns6_minimal.so.2

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -44,9 +44,32 @@ parts:
       # https://github.com/snapcore/snapcraft/pull/2251
       export PATH="$PATH:/snap/snapcraft/current/bin/scriptlet-bin"
       snapcraftctl prime
+  avahi-daemon-equiv-deb:
+    plugin: nil
+    build-packages:
+      - equivs
+    override-build: |
+      cat > avahi-daemon.control << \EOF
+      Section: misc
+      Priority: optional
+      Standards-Version: 3.9.2
+      Architecture: all
+
+      Package: avahi-daemon
+      Version: 1000
+      Multi-Arch: foreign
+      Description: A dummy version of avahi-daemon
+
+      EOF
+      unset LD_FLAGS LD_LIBRARY_PATH
+      equivs-build avahi-daemon.control
+      cp avahi-daemon_*.deb $SNAPCRAFT_PART_INSTALL
+    stage:
+      - -avahi-daemon_*.deb
   bootstrap:
     after:
       - consoleconf-deb
+      - avahi-daemon-equiv-deb
     plugin: make
     source: .
     build-packages:


### PR DESCRIPTION
This PR draft attempts to add optional support for mDNS hostname resolution via Avahi.  In order for it to be useful, Avahi will have to be available (either provided by the distro on classic systems, or via the avahi snap on Core).  If Avahi is not available, the plugin will fail quickly when it can't connect to `/run/avahi-daemon/socket`.

The AppArmor `<abstractions/nameservice>` policy fragment allows communication with this socket, so any snap plugging `network` already has the permissions it needs to communicate with Avahi's hostname resolution socket (which is heavily constrained compared to the D-Bus API).