### PR TITLE
hooks: add libglib2.0-bin for the "gdbus" utility

### DIFF
--- a/hook-tests/001-extra-packages.test
+++ b/hook-tests/001-extra-packages.test
@@ -68,6 +68,7 @@ libfdisk1:amd64
 libffi7:amd64
 libgcc-s1:amd64
 libgcrypt20:amd64
+libglib2.0-bin
 libgmp10:amd64
 libgnutls30:amd64
 libgpg-error0:amd64

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -61,6 +61,7 @@ apt install --no-install-recommends -y \
     less \
     dbus \
     dbus-user-session \
+    libglib2.0-bin \
     vim-tiny \
     bash-completion \
     netcat-openbsd \


### PR DESCRIPTION
I'm proposing this in response to some discussion on IRC.  While writing snapd spread tests for some D-Bus related features, I found myself running into limitations on what I could do with the `dbus-send` utility.  The `gdbus` utility could handle those cases as it can represent arbitrary types when making method calls, but is not included in any of our base snaps. That means using it would require the tests use snaps published to the store, which increases the maintenance burden and makes updates more difficult. @anonymouse64 also noted that he'd run into similar limitations when writing tests.

I believe the `gdbus` utility would also be generally useful in testing D-Bus related faults on Ubuntu Core systems, so it would make sense to include for similar reasons to the `dbus-send` utility.

This PR adds the whole `libglib2.0-bin` package.  I don't expect it to make a large difference to the size of the snap since its dependencies are already included, but I'll check the result of CI. We could trim some of the other utilities from the package if you think that would be appropriate.