### PR TITLE
hooks: add bootchart configuration

### DIFF
--- a/hook-tests/024-configure-bootchart.test
+++ b/hook-tests/024-configure-bootchart.test
@@ -1,0 +1,8 @@
+#!/bin/sh -e
+
+test -f etc/systemd/bootchart.conf
+test -f lib/systemd/system/systemd-bootchart.service
+test -x lib/systemd/systemd-bootchart-prestart.sh
+test -x lib/systemd/systemd-bootchart-poststop.sh
+test -f lib/systemd/system/stop-systemd-bootchart.service
+test -h lib/systemd/system/multi-user.target.wants/stop-systemd-bootchart.service

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -45,6 +45,7 @@ apt update
 apt dist-upgrade -y
 apt install --no-install-recommends -y \
     systemd \
+    systemd-bootchart \
     systemd-sysv \
     finalrd \
     libnss-extrausers \

--- a/hooks/024-configure-bootchart.chroot
+++ b/hooks/024-configure-bootchart.chroot
@@ -1,0 +1,76 @@
+#! /bin/sh -ex
+
+# Rewrite configuration and unit that came with the systemd-bootchart package
+
+cat << 'EOF' > /etc/systemd/bootchart.conf
+[Bootchart]
+Samples=36000
+Frequency=20
+Relative=yes
+Filter=no
+# Memory usage produces a bad overlay in the svg
+#PlotMemoryUsage=yes
+Cmdline=yes
+EOF
+
+cat << 'EOF' > /lib/systemd/system/systemd-bootchart.service
+[Unit]
+Description=Boot Process Profiler
+Documentation=man:systemd-bootchart.service(1) man:bootchart.conf(5)
+DefaultDependencies=no
+Conflicts=shutdown.target
+Before=shutdown.target
+
+[Service]
+ExecStartPre=/usr/bin/mkdir -p /run/log
+ExecStartPre=/lib/systemd/systemd-bootchart-prestart.sh
+ExecStart=/lib/systemd/systemd-bootchart -r
+KillSignal=SIGHUP
+ExecStopPost=/lib/systemd/systemd-bootchart-poststop.sh
+
+[Install]
+WantedBy=sysinit.target
+EOF
+
+# Creating these files could go to static folder, but it seems cleaner to have
+# everything together in one place.
+
+cat << 'EOF' > /lib/systemd/systemd-bootchart-prestart.sh
+#!/bin/sh -ex
+
+chart_f=$(find /run/log -maxdepth 1 -name \*.svg -printf "%f" -quit)
+if [ -n "$chart_f" ]; then
+    mv /run/log/"$chart_f" /run/log/initrd-"$chart_f"
+fi
+EOF
+
+cat << 'EOF' > /lib/systemd/systemd-bootchart-poststop.sh
+#!/bin/sh -ex
+
+save_d=/run/mnt/ubuntu-save/log
+last_d=$(find $save_d/ -type d -name boot\* | sort | tail -n1)
+if [ -z "$last_d" ]; then last_d=0; fi
+next_d=$save_d/boot$((${last_d##*boot} + 1))
+mkdir -p $next_d
+mv /run/log/*.svg $next_d
+EOF
+
+cat << 'EOF' > /lib/systemd/system/stop-systemd-bootchart.service
+[Unit]
+Description=Unit to stop systemd-bootchart
+After=snapd.seeded.service
+Requisite=snapd.seeded.service
+
+[Service]
+Type=oneshot
+ExecStart=sh -c 'if /usr/bin/grep -q snapd_recovery_mode=run /proc/cmdline; then /usr/bin/systemctl stop systemd-bootchart.service; fi'
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+chmod +x /lib/systemd/systemd-bootchart-prestart.sh
+chmod +x /lib/systemd/systemd-bootchart-poststop.sh
+
+ln -s /lib/systemd/system/stop-systemd-bootchart.service \
+   /lib/systemd/system/multi-user.target.wants/stop-systemd-bootchart.service


### PR DESCRIPTION
Add configuration files so it is possible to get a bootchart on
boot. The systemd-bootchart.service will not be enabled by default,
but it will be possible to enable it from kernel command
line (systemd.wants=systemd-bootchart.service) if we want it to run on
first boot