### PR TITLE
hooks: revert PR#105 - it seems to 

### DIFF
--- a/hook-tests/200-enable-time-wait-sync.test
+++ b/hook-tests/200-enable-time-wait-sync.test
@@ -2,8 +2,4 @@
 
 set -e
 
-# ensure we have the systemd-wait-and-sync.service symlink
-s="$(readlink -f etc/systemd/system/sysinit.target.wants/systemd-time-wait-sync.service)"
-echo "$s"
-
-test "$s" = "/lib/systemd/system/systemd-time-wait-sync.service"
+test "$(readlink -f /etc/systemd/system/sysinit.target.wants/systemd-time-wait-sync.service)" = "/usr/lib/systemd/system/systemd-time-wait-sync.service"

--- a/hook-tests/200-enable-time-wait-sync.test
+++ b/hook-tests/200-enable-time-wait-sync.test
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-set -e
-
-test "$(readlink -f /etc/systemd/system/sysinit.target.wants/systemd-time-wait-sync.service)" = "/usr/lib/systemd/system/systemd-time-wait-sync.service"

--- a/hooks/200-enable-time-wait-sync.chroot
+++ b/hooks/200-enable-time-wait-sync.chroot
@@ -1,6 +1,0 @@
-#!/bin/sh
-
-set -e
-
-echo "Enabling systemd-time-wait-sync.service"
-systemctl --root=/ enable systemd-time-wait-sync.service


### PR DESCRIPTION
It looks like adding 105 broke GCE tests. It's unclear why right now, the change works inside qemu. But to unbreak master we need to go back and revert this change.

I'm running a spread test with the services removed please do not merge before this is finished.