### PR TITLE
Copy dpkg yaml for buildd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,10 +51,11 @@ install:
 		rm -f $(DESTDIR)/tmp/$$(basename $$f); \
 	done;
 
-	# only generate manifest file for lp build
+	# only generate manifest and dpkg.yaml file for lp build
 	if [ -e /build/core20 ]; then \
 		echo $$f; \
 		/bin/cp $(DESTDIR)/usr/share/snappy/dpkg.list /build/core20/core20-$$(date +%Y%m%d%H%M)_$(DPKG_ARCH).manifest; \
+		/bin/cp $(DESTDIR)/usr/share/snappy/dpkg.yaml /build/core20/core20-$$(date +%Y%m%d%H%M)_$(DPKG_ARCH).spkg.yaml; \
 	fi;
 
 .PHONY: check

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ install:
 	if [ -e /build/core20 ]; then \
 		echo $$f; \
 		/bin/cp $(DESTDIR)/usr/share/snappy/dpkg.list /build/core20/core20-$$(date +%Y%m%d%H%M)_$(DPKG_ARCH).manifest; \
-		/bin/cp $(DESTDIR)/usr/share/snappy/dpkg.yaml /build/core20/core20-$$(date +%Y%m%d%H%M)_$(DPKG_ARCH).spkg.yaml; \
+		/bin/cp $(DESTDIR)/usr/share/snappy/dpkg.yaml /build/core20/core20-$$(date +%Y%m%d%H%M)_$(DPKG_ARCH).dpkg.yaml; \
 	fi;
 
 .PHONY: check


### PR DESCRIPTION
We will need to copy the yaml file in order to be able to gather it from the Buildd output folder.