### PR TITLE
Fix riscv64 build

### DIFF
--- a/hook-tests/024-configure-bootchart.test
+++ b/hook-tests/024-configure-bootchart.test
@@ -1,5 +1,10 @@
 #!/bin/sh -ex
 
+if [ "$(dpkg --print-architecture)" = "riscv64" ]; then
+    echo "core20 riscv64 does not support this functionality"
+    exit 0
+fi
+
 test -f usr/lib/systemd/bootchart.conf.d/ubuntu-core.conf
 test -f lib/systemd/system/systemd-bootchart.service
 test -x lib/systemd/systemd-bootchart-poststop.sh

--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -45,7 +45,6 @@ apt update
 apt dist-upgrade -y
 apt install --no-install-recommends -y \
     systemd \
-    systemd-bootchart \
     systemd-sysv \
     finalrd \
     libnss-extrausers \
@@ -75,8 +74,15 @@ apt install --no-install-recommends -y \
     wpasupplicant \
     cloud-init \
     dmsetup \
-    cryptsetup \
-    gdbserver
+    cryptsetup
+
+case "$(dpkg --print-architecture)" in
+    riscv64)
+        ;;
+    *)
+        apt install --no-install-recommends -y gdbserver systemd-bootchart
+        ;;
+esac
 
 # Install self-built console-conf and fake avahi-daemon
 find /tmp -name '*.deb' -print0 | xargs -0 apt install -y

--- a/hooks/024-configure-bootchart.chroot
+++ b/hooks/024-configure-bootchart.chroot
@@ -1,5 +1,10 @@
 #! /bin/sh -ex
 
+if [ "$(dpkg --print-architecture)" = "riscv64" ]; then
+    echo "core20 riscv64 does not support this functionality"
+    exit 0
+fi
+
 # Rewrite unit that came with the systemd-bootchart package
 
 cat << 'EOF' > /lib/systemd/system/systemd-bootchart.service


### PR DESCRIPTION
In focal, there are no debs for gdbserver or systemd-bootchart, skip
installing those for now. Also there is no Ubuntu Core for riscv64
either, thus lack of these packages doesn't change featureset for now.

Signed-off-by: Dimitri John Ledkov <dimitri.ledkov@canonical.com>