### PR TITLE
Start bootchart earlier

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,9 @@ doing a manual "make test" in the source tree.
 # Bootchart
 
 It is possible to enable bootcharts by adding
-`systemd.wants=systemd-bootchart.service` to the kernel command
+`core.bootchart` to the kernel command
 line. The sample collector will run until the system is seeded (it will
 stop when the `snapd.seeded.service` stops). The bootchart will be saved
 in the `ubuntu-save` partition, under `log/boot<N>/`, being `<N>` the
 boot number since bootcharts were enabled. If a chart has been collected
-by the initramfs, it will be also saved in that folder (this will happen
-if we have also added `rd.systemd.wants=systemd-bootchart.service` to
-the kernel command line).
+by the initramfs, it will be also saved in that folder.

--- a/README.md
+++ b/README.md
@@ -33,3 +33,10 @@ stop when the `snapd.seeded.service` stops). The bootchart will be saved
 in the `ubuntu-save` partition, under `log/boot<N>/`, being `<N>` the
 boot number since bootcharts were enabled. If a chart has been collected
 by the initramfs, it will be also saved in that folder.
+
+**TODO** In the future, we would want `systemd-bootchart` to be started
+only from the initramfs and have just one bootchart per boot. However,
+this is currently not possible as `systemd-bootchart` needs some changes
+so it can survive the switch root between initramfs and data
+partition. With those changes, we could also have `systemd-bootchart` as
+init process so we get an even more accurate picture.

--- a/hooks/024-configure-bootchart.chroot
+++ b/hooks/024-configure-bootchart.chroot
@@ -15,6 +15,7 @@ DefaultDependencies=no
 Conflicts=shutdown.target
 Before=shutdown.target
 Requires=stop-systemd-bootchart.service
+ConditionKernelCommandLine=core.bootchart
 
 [Service]
 ExecStartPre=/usr/bin/mkdir -p /run/log/base
@@ -25,6 +26,8 @@ ExecStopPost=/lib/systemd/systemd-bootchart-poststop.sh
 [Install]
 WantedBy=sysinit.target
 EOF
+
+systemctl enable systemd-bootchart.service
 
 # Creating these files could go to static folder, but it seems cleaner to have
 # everything together in one place.


### PR DESCRIPTION
Previously, we started systemd-bootchart by adding
systemd.wants=systemd-bootchart.service to the kernel command
line. This has as a side effect that the service is added to the
default target and is started later than desired. Instead, enable the
service by default and use a new kernel command line
parameter (core.bootchart) as condition to start it.