### PR TITLE
hooks: adjtime: add adjtime file to etc

### DIFF
--- a/hook-tests/008-etc-writable.test
+++ b/hook-tests/008-etc-writable.test
@@ -8,6 +8,7 @@ test -e etc/localtime
 test -e etc/hostname
 test -e etc/motd
 test -e etc/issue
+test -e etc/adjtime
 grep -q "Etc/UTC" etc/timezone
 test $(readlink etc/localtime) = "writable/localtime"
 test $(readlink etc/writable/localtime) = "/usr/share/zoneinfo/Etc/UTC"

--- a/hook-tests/102-etc-adjtime.test
+++ b/hook-tests/102-etc-adjtime.test
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+if [ ! -e etc/adjtime ]; then
+    echo "/etc/adjtime must exist"
+    exit 1
+fi
+
+if [ -s etc/adjtime ]; then
+    echo "/etc/adjtime exists but must be empty"
+    exit 1
+fi

--- a/hooks/008-etc-writable.chroot
+++ b/hooks/008-etc-writable.chroot
@@ -4,7 +4,11 @@ mkdir -p /etc/writable/default
 
 # cloud-init needs to be able to modify hostname and has the ability to
 # set the other two.
-for f in timezone localtime hostname motd issue; do
+# additionally we need to allow hwclock to write to adjtime
+
+printf "" > /etc/adjtime
+
+for f in timezone localtime hostname motd issue adjtime; do
     if [ -e /etc/$f ]; then
         echo "I: Moving /etc/$f to /etc/writable/"
         mv /etc/$f /etc/writable/$f

--- a/static/etc/system-image/writable-paths
+++ b/static/etc/system-image/writable-paths
@@ -63,3 +63,5 @@
 # allow system wide proxy setting
 /etc/environment                        auto                    persistent  transition  none
 /etc/machine-id                         auto                    persistent  transition  none
+# allow hwclock to write drift
+/etc/adjtime                            auto                    persistent  transition  none


### PR DESCRIPTION
hwclock command needs to write to /etc/adjtime
to persist drift factor

Signed-off-by: Sertac TULLUK <stulluk@gmail.com>