### PR TITLE
hooks: change folder where to save bootcharts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ doing a manual "make test" in the source tree.
 
 # Bootchart
 
-It is possible to enable bootcharts by adding
-`core.bootchart` to the kernel command
-line. The sample collector will run until the system is seeded (it will
-stop when the `snapd.seeded.service` stops). The bootchart will be saved
-in the `ubuntu-save` partition, under `log/boot<N>/`, being `<N>` the
-boot number since bootcharts were enabled. If a chart has been collected
-by the initramfs, it will be also saved in that folder.
+It is possible to enable bootcharts by adding `core.bootchart` to the
+kernel command line. The sample collector will run until the system is
+seeded (it will stop when the `snapd.seeded.service` stops). The
+bootchart will be saved in the `ubuntu-data` partition, under
+`/var/log/debug/boot<N>/`, `<N>` being the boot number since
+bootcharts were enabled. If a chart has been collected by the
+initramfs, it will be also saved in that folder.
 
 **TODO** In the future, we would want `systemd-bootchart` to be started
 only from the initramfs and have just one bootchart per boot. However,

--- a/hooks/024-configure-bootchart.chroot
+++ b/hooks/024-configure-bootchart.chroot
@@ -48,7 +48,7 @@ EOF
 cat << 'EOF' > /lib/systemd/systemd-bootchart-poststop.sh
 #!/bin/sh -ex
 
-save_d=/run/mnt/ubuntu-save/log
+save_d=/run/mnt/data/system-data/var/log/debug
 last_d=$(find $save_d/ -type d -name boot\* | sort | tail -n1)
 if [ -z "$last_d" ]; then last_d=0; fi
 next_d=$save_d/boot$((${last_d##*boot} + 1))


### PR DESCRIPTION
Use /var/log/debug/boot<N> for saving bootchars instead of the
ubuntu-save partition.