### PR TITLE
Switch to self-hosted runners for Github Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,12 +21,7 @@ jobs:
           mkdir "${{ github.workspace }}"
       - uses: actions/checkout@v2
 
-      - name: Install spread
-        run: curl -s https://storage.googleapis.com/snapd-spread-tests/spread/spread-amd64.tar.gz | sudo tar xzv -C /usr/bin
-
       - name: Run tests
-        env:
-          SPREAD_GOOGLE_KEY: ${{ secrets.SPREAD_GOOGLE_KEY }}
         run: |
           spread google-nested:
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Cleanup job workspace
         id: cleanup-job-workspace


### PR DESCRIPTION
Should fix our PRs for forks.