### PR TITLE
Add a finalrd script to move filesystems

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -74,7 +74,8 @@ apt install --no-install-recommends -y \
     wpasupplicant \
     cloud-init \
     dmsetup \
-    cryptsetup
+    cryptsetup \
+    initramfs-tools-core
 
 case "$(dpkg --print-architecture)" in
     riscv64)

--- a/static/usr/lib/systemd/systemd-shutdown.wrapper
+++ b/static/usr/lib/systemd/systemd-shutdown.wrapper
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# We need to manually move /run/mnt/data after shutdown switch root
+# so that systemd-shutdown can umount /oldroot in the shutdown initramfs.
+# systemd-shutdown has hooks, but they are run either before
+# switch, or after unmounts.
+# It would be better to make systemd-shutdown smarter and move
+# all found mounts before trying to unmount them.
+
+/bin/mount --make-private /oldroot/run
+for name in data ubuntu-seed; do
+  if /bin/mountpoint -q "/oldroot/run/mnt/${name}"; then
+    /bin/mkdir -p "/old-${name}"
+    /bin/mount --move "/oldroot/run/mnt/${name}" "/old-${name}"
+  fi
+done
+
+exec "${0}.real" "$@"

--- a/static/usr/share/finalrd/core.finalrd
+++ b/static/usr/share/finalrd/core.finalrd
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -eu
+
+setup() {
+  . /usr/share/initramfs-tools/hook-functions
+  copy_exec /bin/mkdir
+  copy_exec /bin/mount
+  copy_exec /bin/mountpoint
+  mv "${DESTDIR}/shutdown" "${DESTDIR}/shutdown.real"
+  cp "/usr/lib/systemd/systemd-shutdown.wrapper" "${DESTDIR}/shutdown"
+}
+
+poweroff() {
+  # Everything should have been done in the wrapper
+  true
+}
+
+case "${1-}" in
+  setup)
+    setup
+  ;;
+  halt|poweroff|reboot|kexec)
+    poweroff
+  ;;
+esac


### PR DESCRIPTION
`/mnt/run/base` contains the snap file that is mounted on `/`. For
that reason it is not possible to unmount `/mnt/run/base` until we
have switched root to the shutdown ramfs.

At this point before we move `/sysroot/mnt/run/base` out of `/sysroot`
so that `systemd-shutdown` is able to unmount all filesystems.

`systemd-shutdown` allows hooks. But they are called right after
`systemd-shutdown`. That means we cannot run a hook after the root
switch and before `systemd-shutdown`. For that reason the
finalrd hook replaces `systemd-shutdown` in the ramfs by a wrapper.

This solution is not elegant. In the long term we should try to make
`systemd-shutdown` always move all sub mount points before trying to
unmount.

Also, there is still an error message when systemd tries to umount
`/mnt/run/base` before switching root. There does not seem to be
anyway to make `mnt-run-base.mount` perpetual.