### PR TITLE
static: disable systemd ctrl-alt-del burst action

### DIFF
--- a/hook-tests/020-extra-files.test
+++ b/hook-tests/020-extra-files.test
@@ -4,3 +4,7 @@ test -d snap
 test -d var/snap
 
 test -d host
+
+echo "test static file and folder permissions"
+test "$(stat etc/systemd/system.conf.d -c %a)" = "755"
+test "$(stat etc/systemd/system.conf.d/11-snapd-ctrl-alt-del-burst.conf -c %a)" = "644"

--- a/hooks/020-extra-files.chroot
+++ b/hooks/020-extra-files.chroot
@@ -38,3 +38,7 @@ ln -s ../lib/snapd/snapctl /usr/bin/snapctl
 
 echo "creating host mounts dir"
 mkdir -p /host
+
+echo "set static file and folder permissions"
+chmod 0755 /etc/systemd/system.conf.d
+chmod 0644 /etc/systemd/system.conf.d/11-snapd-ctrl-alt-del-burst.conf

--- a/static/etc/systemd/system.conf.d/11-snapd-ctrl-alt-del-burst.conf
+++ b/static/etc/systemd/system.conf.d/11-snapd-ctrl-alt-del-burst.conf
@@ -1,0 +1,23 @@
+# Snapd allows control of the systemd ctrl-alt-del action
+# by controlling the ctrl-alt-del.target unit (masking it)
+#
+# For example: 
+# snap set core system.ctrl-alt-del-action=none
+#
+# However, systemd implements a parallel emergency action
+# mechanism which still, by default, allows the user to
+# trigger a forced reset by hitting ctrl-alt-del 7 times
+# or more in 2 seconds. Let's make sure this loophole is
+# closed by changing the action to none.
+#
+# The ability to disable this was added in systemd 231, so
+# this can only be disabled in Ubuntu Core 18 and later.
+#
+# Also see: 
+# (1) https://www.stigviewer.com/stig/
+# red_hat_enterprise_linux_8/2021-03-04/finding/V-230531
+# (2) https://github.com/systemd/systemd
+# commit 24dd31c19ede505143833346ff850af942694aa6
+
+[Manager]
+CtrlAltDelBurstAction=none


### PR DESCRIPTION
Systemd provides two ctrl-alt-del keyboard hooks (enabled by default)
exposing Ubuntu Core to malicious reboot request attacks.

(1) Ctrl-alt-del single press
(2) Ctrl-alt-del burst (7 presses or more in 2 seconds)

These issues are acknowledged and one addressed in a systemd commit
(commit: 24dd31c19ede505143833346ff850af942694aa6, 231 and later) by providing
a config item for the systemd manager to disable the ctrl-alt-del burst action.

Issue (1) is addressed in snapd by allowing the ctrl-alt-del.target to be
masked (pull: https://github.com/snapcore/snapd/pull/11113)

Issue (2) is addressed in this patch by disabling burst action in the systemd
manager config using a drop-in configuration file.

Testing: The ctrl-alt-del kernel sequence sends a SIGINT to PID1 (systemd).

The burst sequence was emulated by using a simple bash loop running on
Ubuntu Core (Raspberry Pi 3).

$ while [ true ]; do sudo kill -s SIGINT 1; done

No drop-in: reboot
Drop-in config CtrlAltDelBurstAction=reboot-force: reboot
Drop-in config CtrlAltDelBurstAction=none: no reboot

This patch adds a drop-in systemd config with CtrlAltDelBurstAction=none

The drop-in config file prefix number is set at 11. This follows on 10 which
can be generated by snapd for systemd watchdog control.

Also see:

https://www.stigviewer.com/
stig/red_hat_enterprise_linux_7/2017-12-14/finding/V-71993

https://www.stigviewer.com/
stig/red_hat_enterprise_linux_8/2021-03-04/finding/V-230531

Signed-off-by: Fred Lotter <fred.lotter@canonical.com>