### PR TITLE
Add a PR template that informs of core-base repository

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+Thanks for helping us make a better ubuntu core!
+
+Before continuing with the PR, you might want to consider also creating a PR for the new core-base repository
+at https://github.com/snapcore/core-base, which contains newer core versions (22+), if the PR is also relevant
+for newer core versions.


### PR DESCRIPTION
This should help inform contributors when we do bugfixes for core20 that might also be relevant for core22+.