### PR TITLE
static: remove perl dependency

### DIFF
--- a/static/usr/bin/core-sshd-host-keygen
+++ b/static/usr/bin/core-sshd-host-keygen
@@ -9,10 +9,8 @@ get_config_option() {
 	[ -f /etc/ssh/sshd_config ] || return
 
 	# TODO: actually only one '=' allowed after option
-	perl -lne '
-		s/[[:space:]]+/ /g; s/[[:space:]]+$//;
-		print if s/^[[:space:]]*'"$option"'[[:space:]=]+//i' \
-	   /etc/ssh/sshd_config
+	awk -v option=$option 'tolower($1) == tolower(option) {print $2}' \
+		/etc/ssh/sshd_config
 }
 
 host_keys_required() {


### PR DESCRIPTION
remove perl dependency in base snap


Signed-off-by: Ondrej Kubik <ondrej.kubik@canonical.com>

Thanks for helping us make a better ubuntu core!

Before continuing with the PR, you might want to consider also creating a PR for the new core-base repository
at https://github.com/snapcore/core-base, which contains newer core versions (22+), if the PR is also relevant
for newer core versions.
