### PR TITLE
static: wait with snapd bootstrap after `time-set.target` is reached

### DIFF
--- a/static/usr/lib/systemd/system/core.start-snapd.service
+++ b/static/usr/lib/systemd/system/core.start-snapd.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Start the snapd services from the snapd snap
 RequiresMountsFor=/run
-Wants=secureboot-db.service
-After=secureboot-db.service
+Wants=secureboot-db.service time-set.target
+After=secureboot-db.service time-set.target
 
 [Service]
 ExecStart=/usr/lib/core/run-snapd-from-snap start


### PR DESCRIPTION
We are investigating a case where a missing/broken RTC prevents
the initial seeding. On an empty/unseeded system the
`core.start-snapd.service` needs to wait for the initial (quick)
`time-set.target` too.

Thanks for helping us make a better ubuntu core!

Before continuing with the PR, you might want to consider also creating a PR for the new core-base repository
at https://github.com/snapcore/core-base, which contains newer core versions (22+), if the PR is also relevant
for newer core versions.
