### PR TITLE
Makefile: create /usr/lib/clock-epoch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ install:
                 fi && \
 		rm -f $(DESTDIR)/tmp/$$(basename $$f); \
 	done;
+	# see https://github.com/systemd/systemd/blob/v247/src/shared/clock-util.c#L145
+	touch $(DESTDIR)/usr/lib/clock-epoch
 
 	# only generate manifest and dpkg.yaml file for lp build
 	if [ -e /build/core20 ]; then \


### PR DESCRIPTION
When there is no RTC systemd will use either it's own build date
or `/usr/lib/clock-epoch` to "seed" the initial time. So far we
did not create /usr/lib/clock-epoch but this commit adds it.

Thanks for helping us make a better ubuntu core!

This should also get cherry picked for core22+