### PR TITLE
hooks: make sure that upgrade is never interactive

### DIFF
--- a/hooks/001-extra-packages.chroot
+++ b/hooks/001-extra-packages.chroot
@@ -42,7 +42,7 @@ EOF
 
 # install some packages we need
 apt update
-apt dist-upgrade -y
+apt dist-upgrade -y -o Dpkg::Options::=--force-confnew
 apt install --no-install-recommends -y \
     systemd \
     systemd-sysv \


### PR DESCRIPTION
In some cases builds have failed when configuration files in the new version to be upgraded are different from those in the build system.
