### PR TITLE
get-arg: fix call to printf

### DIFF
--- a/static/usr/libexec/core/get-arg
+++ b/static/usr/libexec/core/get-arg
@@ -31,7 +31,7 @@ fi
 set --
 
 # We cannot use ANSI-C quoting (e.g. $'\n') in busybox-initramfs
-whitespaces="$(printf '\t\n\v\f\r \xA0')"
+whitespaces="$(printf '\t\n\v\f\r \240')"
 in_quote=no
 param=
 current="${cmdline}"


### PR DESCRIPTION
Anything with and "A" or a "0" in the name was not parsed correctly and interpreted as a space instead.

Backport of https://github.com/snapcore/core-base/pull/129