### PR TITLE
static/usr/lib: add rule to override rtc symlink according to kernel param ubuntu_core.rtc_sys_init_time

### DIFF
--- a/static/usr/lib/udev/rules.d/90-rtc-sys-time-init.rules
+++ b/static/usr/lib/udev/rules.d/90-rtc-sys-time-init.rules
@@ -10,3 +10,8 @@ ACTION=="add", SUBSYSTEM=="rtc", KERNEL=="rtc*", ATTR{hctosys}=="1", ENV{ubuntu_
 # enabled by generator rtc-sys-time-init-generator when kernel command line contains parameter
 # ubuntu_core.rtc_sys_time_init=/dev/rtc*
 ACTION=="add", SUBSYSTEM=="rtc", KERNEL=="rtc*", TAG+="systemd"
+
+# When device rtc* match the device node specified by the kernel command line parameter ubuntu_core.rtc_sys_time_init
+# create symlink to the device node. In older kernels where attribute hctosys is not set for loadable modules this
+# rule overrides the default symlink to /dev/rtc0 created by 50-udev-default.rules.
+ACTION=="add", SUBSYSTEM=="rtc", KERNEL=="rtc*", PROGRAM="/bin/sh -c '[ $env{ubuntu_core.rtc_sys_time_init} !=  $devnode ] && echo link'", RESULT=="link", SYMLINK+="rtc", OPTIONS+="link_priority=100"


### PR DESCRIPTION
Currently, for kernel version that do not initialise RTC for loadable modules (hctosys==0), a rule in `50-udev-default.rules` will link /dev/rtc0 to /dev/rtc. 

The problem is that in the case where someone specifies kernel param `ubuntu_core.rtc_sys_time_init=/dev/rtc1` this is not expected, and would require injecting a custom udev rule to create the intended link /dev/rtc1 to /dev/rtc.

This change proposes to add a rule as part of the core20 that deals with that in a generic manner, so that udev rule customisation us not required.

CONCLUSION:  Abandon
After discussion  we Valentin we concluded that this change is not ideal and since there exist a workaround that is already used this should not be a problem. One of the main concerns with adding this kind of capability is that the kernel cmdline param now have the power to create a different symlink to /dev/rtc that intended by the kernel configuration, and its not simple to reliable get the kernel configuration information. This only impacts UC with older kernel (<5.15), so not expected to impact UC22 and higher.