### PR TITLE
static/usr/lib: rtc-sys-time-init@.service must remain after exit

### DIFF
--- a/static/usr/lib/systemd/system/rtc-sys-time-init@.service
+++ b/static/usr/lib/systemd/system/rtc-sys-time-init@.service
@@ -25,4 +25,5 @@ Before=shutdown.target
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/lib/core/rtc-sys-time-init /%I


### PR DESCRIPTION
Backport from core-base change to make service rtc-sys-time-init@.service remain after exit.
This is not because of a functional issue, but precautionary, since it did cause functional issues in core-base main & core22
See the [original PR commit](https://github.com/snapcore/core-base/pull/139/commits/d5e9e231964d598015b97499f0fcded41579cc4f)
