### PR TITLE
Stop running auto-import directly from udevd

### DIFF
--- a/static/usr/lib/systemd/system/snapd.autoimport-device@.service
+++ b/static/usr/lib/systemd/system/snapd.autoimport-device@.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Auto import assertions from a specific block device
+After=snapd.service snapd.socket snapd.seeded.service
+ConditionKernelCommandLine=snapd_recovery_mode=run
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/snap auto-import --mount=/dev/%i
+PrivateMounts=yes

--- a/static/usr/lib/udev/rules.d/66-snapd-autoimport.rules
+++ b/static/usr/lib/udev/rules.d/66-snapd-autoimport.rules
@@ -1,3 +1,2 @@
-# probe for assertions, must run before udisks2
-ACTION=="add", SUBSYSTEM=="block", KERNEL!="loop*", KERNEL!="ram*" \
-    RUN+="/usr/bin/unshare -m /usr/bin/snap auto-import --mount=/dev/%k"
+ACTION=="add|change", SUBSYSTEM=="block", KERNEL!="loop*", KERNEL!="ram*" \
+    ENV{SYSTEMD_WANTS}+="snapd.autoimport-device@%k.service"

--- a/static/usr/lib/udev/rules.d/66-snapd-autoimport.rules
+++ b/static/usr/lib/udev/rules.d/66-snapd-autoimport.rules
@@ -1,2 +1,2 @@
-ACTION=="add|change", SUBSYSTEM=="block", KERNEL!="loop*", KERNEL!="ram*" \
+ACTION=="add|change", SUBSYSTEM=="block", KERNEL!="loop*", KERNEL!="ram*", ENV{ID_FS_USAGE}=="filesystem" \
     ENV{SYSTEMD_WANTS}+="snapd.autoimport-device@%k.service"


### PR DESCRIPTION
This is a backport of https://github.com/snapcore/core-base/pull/35 and https://github.com/snapcore/core-base/pull/165

Currently, user assertions do not work on first boot which make snapd spread test fail. The reason is because it tries to run "snap" command before snapd is mounted. The issue does not appear to be a problem on UC 22, because the service has implicit dependencies to snapd being mounted. So let's do the same on UC 20.

Original commit message:

`snap auto-import` cannot run anymore because of sandboxing of systemd-udevd. Instead we need to schedule a systemd service.

Thanks for helping us make a better ubuntu core!

Before continuing with the PR, you might want to consider also creating a PR for the new core-base repository
at https://github.com/snapcore/core-base, which contains newer core versions (22+), if the PR is also relevant
for newer core versions.
