### PR TITLE
snapd.autoimport-device@.service: do not run along snapd.autoimport.service

### DIFF
--- a/static/usr/lib/systemd/system/snapd.autoimport-device@.service
+++ b/static/usr/lib/systemd/system/snapd.autoimport-device@.service
@@ -1,6 +1,8 @@
 [Unit]
 Description=Auto import assertions from a specific block device
 After=snapd.service snapd.socket snapd.seeded.service
+# snapd.autoimport.service might try to mount the same disks so run after
+After=snapd.autoimport.service
 ConditionKernelCommandLine=snapd_recovery_mode=run
 
 [Service]


### PR DESCRIPTION
Backport of https://github.com/snapcore/core-base/pull/173

There is a conflict between snapd.autoimport.service and snapd.autoimport-device@.service. This causes error messages because both cannot mount in the same time. So they cannot be run at the same time.
